### PR TITLE
Adapt bonus scheme view to procedure output

### DIFF
--- a/src/main/frontend/src/app/app.component.html
+++ b/src/main/frontend/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-acts></app-acts>
+<app-bonus-scheme></app-bonus-scheme>

--- a/src/main/frontend/src/app/app.component.ts
+++ b/src/main/frontend/src/app/app.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { BonusSchemeComponent } from './components/bonus-scheme/bonus-scheme.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [BonusSchemeComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/src/main/frontend/src/app/components/bonus-scheme/bonus-scheme.component.css
+++ b/src/main/frontend/src/app/components/bonus-scheme/bonus-scheme.component.css
@@ -1,0 +1,176 @@
+:host {
+  display: block;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: #0f172a;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 56px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 24px;
+  align-items: center;
+}
+
+h1 {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+}
+
+h2 {
+  margin: 4px 0 0;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.lead {
+  color: #475569;
+  line-height: 1.5;
+  margin: 12px 0 0;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #6366f1;
+  font-size: 12px;
+  margin: 0 0 6px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 14px 50px rgba(79, 70, 229, 0.1);
+  padding: 20px;
+  border: 1px solid #e2e8f0;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.badge {
+  background: #eef2ff;
+  color: #3730a3;
+  border-radius: 9999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+input,
+select {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.primary {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: white;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 700;
+  margin-top: 12px;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(99, 102, 241, 0.35);
+}
+
+.hint {
+  color: #64748b;
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.table-wrapper {
+  overflow: auto;
+  max-height: 360px;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+th,
+td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+th {
+  background: #f8fafc;
+  font-weight: 700;
+}
+
+tr:nth-child(even) td {
+  background: #f9fafb;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/main/frontend/src/app/components/bonus-scheme/bonus-scheme.component.html
+++ b/src/main/frontend/src/app/components/bonus-scheme/bonus-scheme.component.html
@@ -1,0 +1,172 @@
+<div class="page">
+  <section class="hero">
+    <div>
+      <p class="eyebrow">Новая схема бонусов</p>
+      <h1>Управление схемами бонусов</h1>
+      <p class="lead">Заполните форму, чтобы добавить новую запись в справочник схем и посмотрите актуальные лимиты, проценты и должности.</p>
+    </div>
+    <div class="card">
+      <form [formGroup]="schemeForm" (ngSubmit)="addScheme()" class="form-grid">
+        <label>
+          ID схемы
+          <input type="number" formControlName="schemeId" min="1" />
+          <span class="hint">Например: 1, 2 или 3</span>
+        </label>
+        <label>
+          Должность
+          <select formControlName="positionId">
+            <option *ngFor="let position of orderedPositions()" [value]="position.id">{{ position.name }}</option>
+          </select>
+        </label>
+        <label>
+          GAP %
+          <select formControlName="gapId">
+            <option *ngFor="let gap of orderedGaps()" [value]="gap.id">{{ gap.percent }} %</option>
+          </select>
+        </label>
+        <label>
+          Подразделение
+          <input type="number" formControlName="divisionId" min="1" />
+        </label>
+        <label>
+          Лимит, ₽
+          <input type="number" formControlName="limit" min="0" step="1000" />
+          <span class="hint">Сумма рассчитывается в рублях</span>
+        </label>
+        <label>
+          Дата схемы
+          <input type="date" formControlName="dateScheme" />
+        </label>
+        <button type="submit" class="primary">Сохранить запись</button>
+      </form>
+    </div>
+  </section>
+
+  <section class="grid">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <p class="eyebrow">Справочник</p>
+          <h2>GAP проценты</h2>
+        </div>
+        <span class="badge">{{ orderedGaps().length }} записей</span>
+      </header>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Процент</th>
+              <th>Дата</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let gap of orderedGaps()">
+              <td>{{ gap.id }}</td>
+              <td>{{ gap.percent }} %</td>
+              <td>{{ gap.schemeDate }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <p class="eyebrow">Справочник</p>
+          <h2>Должности</h2>
+        </div>
+        <span class="badge">{{ orderedPositions().length }} записей</span>
+      </header>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Название</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let position of orderedPositions()">
+              <td>{{ position.id }}</td>
+              <td>{{ position.name }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="grid">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <p class="eyebrow">Контроль</p>
+          <h2>Лимиты по схемам</h2>
+        </div>
+        <span class="badge">{{ orderedLimits().length }} записей</span>
+      </header>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Должность</th>
+              <th>GAP %</th>
+              <th>Подразделение</th>
+              <th>Лимит</th>
+              <th>Дата</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let limit of orderedLimits()">
+              <td>{{ limit.id }}</td>
+              <td>{{ positionName(limit.positionId) }}</td>
+              <td>{{ gapPercent(limit.gapId) }} %</td>
+              <td>{{ limit.divisionId }}</td>
+              <td>{{ formatCurrency(limit.limits) }}</td>
+              <td>{{ limit.schemeLimitsDate }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <header class="card-header">
+      <div>
+        <p class="eyebrow">Справочник</p>
+        <h2>Текущие схемы</h2>
+      </div>
+      <span class="badge">{{ orderedSchemes().length }} записей</span>
+    </header>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Схема</th>
+            <th>Должность</th>
+            <th>GAP %</th>
+            <th>Лимит</th>
+            <th>Подразделение</th>
+            <th>Дата</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let scheme of orderedSchemes()">
+            <td>{{ scheme.id }}</td>
+            <td>#{{ scheme.schemeId }}</td>
+            <td>{{ positionName(scheme.positionId) }}</td>
+            <td>{{ gapPercent(scheme.gapId) }} %</td>
+            <td>{{ formatCurrency(scheme.limit) }}</td>
+            <td>{{ scheme.divisionId ?? '—' }}</td>
+            <td>{{ scheme.dateScheme }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/src/main/frontend/src/app/components/bonus-scheme/bonus-scheme.component.ts
+++ b/src/main/frontend/src/app/components/bonus-scheme/bonus-scheme.component.ts
@@ -1,0 +1,142 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+
+interface Gap {
+  id: number;
+  percent: number;
+  schemeDate: string;
+}
+
+interface Position {
+  id: number;
+  name: string;
+}
+
+interface SchemeLimit {
+  id: number;
+  limits: number;
+  positionId: number;
+  gapId: number;
+  divisionId: number;
+  schemeLimitsDate: string;
+}
+
+interface BonusSchemeEntry {
+  id: number;
+  schemeId: number;
+  limit: number;
+  positionId: number;
+  gapId: number;
+  divisionId?: number;
+  dateScheme: string;
+}
+
+@Component({
+  selector: 'app-bonus-scheme',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './bonus-scheme.component.html',
+  styleUrl: './bonus-scheme.component.css'
+})
+export class BonusSchemeComponent {
+  private readonly gaps: Gap[] = [
+    { id: 1, percent: 3, schemeDate: '2021-01-01' },
+    { id: 2, percent: 5, schemeDate: '2021-01-01' },
+    { id: 3, percent: 7, schemeDate: '2021-01-01' },
+    { id: 16, percent: 17, schemeDate: '2021-01-01' },
+    { id: 17, percent: 25, schemeDate: '2024-07-01' },
+    { id: 20, percent: 26, schemeDate: '2024-09-12' }
+  ];
+
+  private readonly positions: Position[] = [
+    { id: 1, name: 'R2' },
+    { id: 4, name: 'K3' },
+    { id: 7, name: 'BDM' },
+    { id: 10, name: 'Manager' },
+    { id: 13, name: 'K4 Junior' },
+    { id: 27, name: 'K3+R Эксперт' }
+  ];
+
+  private readonly limits = signal<SchemeLimit[]>([
+    { id: 1, limits: 520000, positionId: 7, gapId: 2, divisionId: 2, schemeLimitsDate: '2021-01-01' },
+    { id: 3, limits: 750000, positionId: 7, gapId: 6, divisionId: 2, schemeLimitsDate: '2021-01-01' },
+    { id: 14, limits: 830000, positionId: 7, gapId: 3, divisionId: 3, schemeLimitsDate: '2021-01-01' },
+    { id: 32, limits: 1150000, positionId: 7, gapId: 16, divisionId: 3, schemeLimitsDate: '2024-07-01' },
+    { id: 40, limits: 1450000, positionId: 7, gapId: 19, divisionId: 3, schemeLimitsDate: '2024-07-01' },
+    { id: 67, limits: 1120000, positionId: 7, gapId: 19, divisionId: 7, schemeLimitsDate: '2024-07-01' }
+  ]);
+
+  private nextSchemeId = 1000;
+
+  protected readonly schemeEntries = signal<BonusSchemeEntry[]>([
+    { id: 1, schemeId: 1, limit: 0, positionId: 4, gapId: 4, dateScheme: '2021-01-01' },
+    { id: 8, schemeId: 1, limit: 360000, positionId: 3, gapId: 9, dateScheme: '2021-01-01' },
+    { id: 54, schemeId: 3, limit: 0, positionId: 20, gapId: 4, dateScheme: '2021-01-01' },
+    { id: 70, schemeId: 1, limit: 750000, positionId: 4, gapId: 9, dateScheme: '2022-10-01' },
+    { id: 128, schemeId: 4, limit: 0, positionId: 23, gapId: 10, dateScheme: '2021-01-01' },
+    { id: 175, schemeId: 3, limit: 850000, positionId: 4, gapId: 9, dateScheme: '2024-07-01' },
+    { id: 263, schemeId: 1, limit: 850000, positionId: 27, gapId: 17, dateScheme: '2024-07-01' },
+    { id: 627, schemeId: 1, limit: 850000, positionId: 27, gapId: 17, dateScheme: '2024-10-01' }
+  ]);
+
+  protected readonly schemeForm = this.fb.group({
+    schemeId: [1, [Validators.required, Validators.min(1)]],
+    positionId: [this.positions[0].id, Validators.required],
+    gapId: [this.gaps[0].id, Validators.required],
+    divisionId: [1, [Validators.required, Validators.min(1)]],
+    limit: [0, [Validators.required, Validators.min(0)]],
+    dateScheme: [this.getToday(), Validators.required]
+  });
+
+  readonly orderedGaps = computed(() => this.gaps.sort((a, b) => a.id - b.id));
+  readonly orderedPositions = computed(() => this.positions.sort((a, b) => a.name.localeCompare(b.name)));
+  readonly orderedLimits = computed(() => this.limits().slice().sort((a, b) => a.id - b.id));
+  readonly orderedSchemes = computed(() => this.schemeEntries().slice().sort((a, b) => b.id - a.id));
+
+  constructor(private readonly fb: FormBuilder) {}
+
+  protected addScheme(): void {
+    if (this.schemeForm.invalid) {
+      this.schemeForm.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.schemeForm.value;
+    const newEntry: BonusSchemeEntry = {
+      id: ++this.nextSchemeId,
+      schemeId: formValue.schemeId!,
+      positionId: formValue.positionId!,
+      gapId: formValue.gapId!,
+      divisionId: formValue.divisionId!,
+      limit: formValue.limit!,
+      dateScheme: formValue.dateScheme!
+    };
+
+    this.schemeEntries.update((entries) => [newEntry, ...entries]);
+    this.schemeForm.reset({
+      schemeId: formValue.schemeId,
+      positionId: formValue.positionId,
+      gapId: formValue.gapId,
+      divisionId: formValue.divisionId,
+      limit: 0,
+      dateScheme: formValue.dateScheme
+    });
+  }
+
+  protected formatCurrency(value: number): string {
+    return new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 }).format(value);
+  }
+
+  protected positionName(positionId: number): string {
+    return this.positions.find((p) => p.id === positionId)?.name ?? '—';
+  }
+
+  protected gapPercent(gapId: number): number | string {
+    return this.gaps.find((g) => g.id === gapId)?.percent ?? '—';
+  }
+
+  private getToday(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+}

--- a/src/main/java/ru/alta/thirdproj/controllers/BonusSchemeController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/BonusSchemeController.java
@@ -1,0 +1,42 @@
+package ru.alta.thirdproj.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import ru.alta.thirdproj.entites.BonusSchemeEntry;
+import ru.alta.thirdproj.entites.BonusSchemeRangeTable;
+import ru.alta.thirdproj.services.BonusSchemeService;
+
+@Controller
+@RequestMapping("/bonus-schemes")
+public class BonusSchemeController {
+
+    private final BonusSchemeService bonusSchemeService;
+
+    @Autowired
+    public BonusSchemeController(BonusSchemeService bonusSchemeService) {
+        this.bonusSchemeService = bonusSchemeService;
+    }
+
+    @GetMapping
+    public String showSchemePage(Model model) {
+        BonusSchemeRangeTable rangeTable = bonusSchemeService.getSchemeRangeTable();
+        model.addAttribute("rangeColumns", rangeTable.getColumns());
+        model.addAttribute("rangeRows", rangeTable.getRows());
+        model.addAttribute("gaps", bonusSchemeService.getGaps());
+        model.addAttribute("positions", bonusSchemeService.getPositions());
+        model.addAttribute("schemeNames", bonusSchemeService.getSchemeNames());
+        model.addAttribute("schemeEntry", new BonusSchemeEntry());
+        return "bonus-schemes";
+    }
+
+    @PostMapping
+    public String addScheme(@ModelAttribute("schemeEntry") BonusSchemeEntry entry) {
+        bonusSchemeService.addScheme(entry);
+        return "redirect:/bonus-schemes";
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusGap.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusGap.java
@@ -1,0 +1,24 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusGap {
+
+    private Integer gapId;
+    private BigDecimal gapPercent;
+    private Timestamp schemeDate;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("gap_id", "gapId");
+        COLUMN_MAPPINGS.put("gap_percent", "gapPercent");
+        COLUMN_MAPPINGS.put("scheme_date", "schemeDate");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusPosition.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusPosition.java
@@ -1,0 +1,20 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusPosition {
+
+    private Integer id;
+    private String posName;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("id", "id");
+        COLUMN_MAPPINGS.put("pos_name", "posName");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeBdmLimit.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeBdmLimit.java
@@ -1,0 +1,30 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusSchemeBdmLimit {
+
+    private Integer id;
+    private BigDecimal limits;
+    private Integer positionId;
+    private Integer gapId;
+    private Integer divisionId;
+    private Timestamp schemeLimitsDate;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("id", "id");
+        COLUMN_MAPPINGS.put("limits", "limits");
+        COLUMN_MAPPINGS.put("position_id", "positionId");
+        COLUMN_MAPPINGS.put("gap_id", "gapId");
+        COLUMN_MAPPINGS.put("division_id", "divisionId");
+        COLUMN_MAPPINGS.put("scheme_limits_date", "schemeLimitsDate");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeEntry.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeEntry.java
@@ -1,0 +1,30 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusSchemeEntry {
+
+    private Integer id;
+    private Integer schemeId;
+    private BigDecimal limits;
+    private Integer positionId;
+    private Integer gapId;
+    private LocalDate dateScheme;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("id", "id");
+        COLUMN_MAPPINGS.put("scheme_id", "schemeId");
+        COLUMN_MAPPINGS.put("limits", "limits");
+        COLUMN_MAPPINGS.put("position_id", "positionId");
+        COLUMN_MAPPINGS.put("gap_id", "gapId");
+        COLUMN_MAPPINGS.put("date_scheme", "dateScheme");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeLimit.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeLimit.java
@@ -1,0 +1,30 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusSchemeLimit {
+
+    private Integer id;
+    private Integer schemeId;
+    private BigDecimal limits;
+    private Integer positionId;
+    private Integer gapId;
+    private Timestamp dateScheme;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("id", "id");
+        COLUMN_MAPPINGS.put("scheme_id", "schemeId");
+        COLUMN_MAPPINGS.put("limits", "limits");
+        COLUMN_MAPPINGS.put("position_id", "positionId");
+        COLUMN_MAPPINGS.put("gap_id", "gapId");
+        COLUMN_MAPPINGS.put("date_scheme", "dateScheme");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeLimitView.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeLimitView.java
@@ -1,0 +1,28 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusSchemeLimitView {
+
+    private String positionName;
+    private String schemeName;
+    private BigDecimal limits;
+    private BigDecimal gapPercent;
+    private Timestamp dateScheme;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("pos_name", "positionName");
+        COLUMN_MAPPINGS.put("scheme_name", "schemeName");
+        COLUMN_MAPPINGS.put("limits", "limits");
+        COLUMN_MAPPINGS.put("gap_percent", "gapPercent");
+        COLUMN_MAPPINGS.put("date_scheme", "dateScheme");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeName.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeName.java
@@ -1,0 +1,20 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusSchemeName {
+
+    private Integer id;
+    private String schemeName;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("id", "id");
+        COLUMN_MAPPINGS.put("scheme_name", "schemeName");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeRangeTable.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeRangeTable.java
@@ -4,11 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.List;
-import java.util.Map;
 
 @Data
 @AllArgsConstructor
 public class BonusSchemeRangeTable {
     private List<String> columns;
-    private List<Map<String, Object>> rows;
+    private List<List<Object>> rows;
 }

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeRangeTable.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeRangeTable.java
@@ -1,0 +1,14 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+public class BonusSchemeRangeTable {
+    private List<String> columns;
+    private List<Map<String, Object>> rows;
+}

--- a/src/main/java/ru/alta/thirdproj/entites/BonusSchemeRangeView.java
+++ b/src/main/java/ru/alta/thirdproj/entites/BonusSchemeRangeView.java
@@ -1,0 +1,30 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class BonusSchemeRangeView {
+
+    private String positionName;
+    private String schemeName;
+    private BigDecimal limitFrom;
+    private BigDecimal limitTo;
+    private BigDecimal gapPercent;
+    private Timestamp dateScheme;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("pos_name", "positionName");
+        COLUMN_MAPPINGS.put("scheme_name", "schemeName");
+        COLUMN_MAPPINGS.put("limit_from", "limitFrom");
+        COLUMN_MAPPINGS.put("limit_to", "limitTo");
+        COLUMN_MAPPINGS.put("gap_percent", "gapPercent");
+        COLUMN_MAPPINGS.put("date_scheme", "dateScheme");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusSchemeRepository.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusSchemeRepository.java
@@ -13,9 +13,7 @@ import ru.alta.thirdproj.entites.BonusSchemeRangeTable;
 import ru.alta.thirdproj.entites.BonusSchemeName;
 import ru.alta.thirdproj.entites.BonusSchemeBdmLimit;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.sql2o.data.Table;
 
@@ -88,14 +86,10 @@ public class BonusSchemeRepository {
                     .map(column -> column.getName())
                     .collect(Collectors.toList());
 
-            List<Map<String, Object>> rows = table.rows().stream()
-                    .map(row -> {
-                        Map<String, Object> mappedRow = new LinkedHashMap<>();
-                        for (String columnName : columnNames) {
-                            mappedRow.put(columnName, row.getObject(columnName));
-                        }
-                        return mappedRow;
-                    })
+            List<List<Object>> rows = table.rows().stream()
+                    .map(row -> columnNames.stream()
+                            .map(row::getObject)
+                            .collect(Collectors.toList()))
                     .collect(Collectors.toList());
 
             return new BonusSchemeRangeTable(columnNames, rows);

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusSchemeRepository.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusSchemeRepository.java
@@ -1,0 +1,134 @@
+package ru.alta.thirdproj.repositories;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.sql2o.Connection;
+import org.sql2o.Sql2o;
+import ru.alta.thirdproj.entites.BonusGap;
+import ru.alta.thirdproj.entites.BonusPosition;
+import ru.alta.thirdproj.entites.BonusSchemeEntry;
+import ru.alta.thirdproj.entites.BonusSchemeLimit;
+import ru.alta.thirdproj.entites.BonusSchemeLimitView;
+import ru.alta.thirdproj.entites.BonusSchemeRangeTable;
+import ru.alta.thirdproj.entites.BonusSchemeName;
+import ru.alta.thirdproj.entites.BonusSchemeBdmLimit;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.sql2o.data.Table;
+
+@Component
+public class BonusSchemeRepository {
+
+    private final Sql2o sql2o;
+
+    private static final String SELECT_GAPS = "SELECT gap_id, gap_percent, scheme_date FROM gap";
+    private static final String SELECT_POSITIONS = "SELECT id, pos_name FROM position";
+    private static final String SELECT_LIMITS = "SELECT id, scheme_id, limits, position_id, gap_id, date_scheme FROM scheme_limits";
+    private static final String SELECT_SCHEMES_BDN = "SELECT id, limits, position_id, gap_id, division_id, scheme_limits_date  FROM scheme_limits_bdm";
+    private static final String SELECT_SCHEMES_NAME = "SELECT id, scheme_name FROM scheme";
+    private static final String SELECT_LIMIT_DETAILS = "SELECT p.pos_name, s.scheme_name, sl.limits, g.gap_percent, sl.date_scheme " +
+            "FROM scheme_limits sl " +
+            "JOIN gap g ON g.gap_id = sl.gap_id " +
+            "JOIN position p ON p.id = sl.position_id " +
+            "JOIN scheme s ON s.id = sl.scheme_id " +
+            "JOIN (SELECT scheme_id, position_id, MAX(date_scheme) AS max_date FROM scheme_limits GROUP BY scheme_id, position_id) latest " +
+            "  ON latest.scheme_id = sl.scheme_id AND latest.position_id = sl.position_id AND latest.max_date = sl.date_scheme " +
+            "ORDER BY s.scheme_name, p.pos_name, sl.limits";
+
+    private static final String EXEC_RANGE_DETAILS = "EXEC dbo.GetRangeDetails";
+    private static final String INSERT_SCHEME = "INSERT INTO scheme_limits(scheme_id, limits, position_id, gap_id, date_scheme)\n" +
+            "     VALUES (:scheme_id, :limits, :position_id, :gap_id, :date_scheme)";
+
+    @Autowired
+    public BonusSchemeRepository(Sql2o sql2o) {
+        this.sql2o = sql2o;
+    }
+
+    public List<BonusGap> findAllGaps() {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_GAPS, false)
+                    .setColumnMappings(BonusGap.COLUMN_MAPPINGS)
+                    .executeAndFetch(BonusGap.class);
+        }
+    }
+
+    public List<BonusPosition> findAllPositions() {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_POSITIONS, false)
+                    .setColumnMappings(BonusPosition.COLUMN_MAPPINGS)
+                    .executeAndFetch(BonusPosition.class);
+        }
+    }
+
+    public List<BonusSchemeLimit> findAllLimits() {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_LIMITS, false)
+                    .setColumnMappings(BonusSchemeLimit.COLUMN_MAPPINGS)
+                    .executeAndFetch(BonusSchemeLimit.class);
+        }
+    }
+
+    public List<BonusSchemeLimitView> findAllLimitDetails() {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_LIMIT_DETAILS, false)
+                    .setColumnMappings(BonusSchemeLimitView.COLUMN_MAPPINGS)
+                    .executeAndFetch(BonusSchemeLimitView.class);
+        }
+    }
+
+    public BonusSchemeRangeTable findRangeTable() {
+        try (Connection connection = sql2o.open()) {
+            Table table = connection.createQuery(EXEC_RANGE_DETAILS, false)
+                    .executeAndFetchTable();
+
+            List<String> columnNames = table.columns().stream()
+                    .map(column -> column.getName())
+                    .collect(Collectors.toList());
+
+            List<Map<String, Object>> rows = table.rows().stream()
+                    .map(row -> {
+                        Map<String, Object> mappedRow = new LinkedHashMap<>();
+                        for (String columnName : columnNames) {
+                            mappedRow.put(columnName, row.getObject(columnName));
+                        }
+                        return mappedRow;
+                    })
+                    .collect(Collectors.toList());
+
+            return new BonusSchemeRangeTable(columnNames, rows);
+        }
+    }
+
+    public List<BonusSchemeBdmLimit> findAllBdmSchemes() {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_SCHEMES_BDN, false)
+                    .setColumnMappings(BonusSchemeBdmLimit.COLUMN_MAPPINGS)
+                    .executeAndFetch(BonusSchemeBdmLimit.class);
+        }
+    }
+
+    public List<BonusSchemeName> findAllSchemeNames() {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_SCHEMES_NAME, false)
+                    .setColumnMappings(BonusSchemeName.COLUMN_MAPPINGS)
+                    .executeAndFetch(BonusSchemeName.class);
+        }
+    }
+
+    public void saveSchemeEntry(BonusSchemeEntry entry) {
+        try (Connection connection = sql2o.beginTransaction()) {
+            connection.createQuery(INSERT_SCHEME)
+                    .addParameter("scheme_id", entry.getSchemeId())
+                    .addParameter("limits", entry.getLimits())
+                    .addParameter("position_id", entry.getPositionId())
+                    .addParameter("gap_id", entry.getGapId())
+                    .addParameter("date_scheme", entry.getDateScheme())
+                    .executeUpdate();
+
+            connection.commit();
+        }
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/services/BonusSchemeService.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusSchemeService.java
@@ -1,0 +1,31 @@
+package ru.alta.thirdproj.services;
+
+import ru.alta.thirdproj.entites.BonusGap;
+import ru.alta.thirdproj.entites.BonusPosition;
+import ru.alta.thirdproj.entites.BonusSchemeBdmLimit;
+import ru.alta.thirdproj.entites.BonusSchemeEntry;
+import ru.alta.thirdproj.entites.BonusSchemeLimit;
+import ru.alta.thirdproj.entites.BonusSchemeLimitView;
+import ru.alta.thirdproj.entites.BonusSchemeName;
+import ru.alta.thirdproj.entites.BonusSchemeRangeTable;
+
+import java.util.List;
+
+public interface BonusSchemeService {
+
+    List<BonusGap> getGaps();
+
+    List<BonusPosition> getPositions();
+
+    List<BonusSchemeLimit> getSchemeLimits();
+
+    List<BonusSchemeLimitView> getSchemeLimitDetails();
+
+    BonusSchemeRangeTable getSchemeRangeTable();
+
+    List<BonusSchemeBdmLimit> getBdmLimits();
+
+    List<BonusSchemeName> getSchemeNames();
+
+    void addScheme(BonusSchemeEntry entry);
+}

--- a/src/main/java/ru/alta/thirdproj/services/BonusSchemeServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusSchemeServiceImpl.java
@@ -1,0 +1,70 @@
+package ru.alta.thirdproj.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.alta.thirdproj.entites.BonusGap;
+import ru.alta.thirdproj.entites.BonusPosition;
+import ru.alta.thirdproj.entites.BonusSchemeBdmLimit;
+import ru.alta.thirdproj.entites.BonusSchemeEntry;
+import ru.alta.thirdproj.entites.BonusSchemeLimit;
+import ru.alta.thirdproj.entites.BonusSchemeLimitView;
+import ru.alta.thirdproj.entites.BonusSchemeName;
+import ru.alta.thirdproj.entites.BonusSchemeRangeTable;
+import ru.alta.thirdproj.repositories.BonusSchemeRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class BonusSchemeServiceImpl implements BonusSchemeService {
+
+    private final BonusSchemeRepository repository;
+
+    @Autowired
+    public BonusSchemeServiceImpl(BonusSchemeRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<BonusGap> getGaps() {
+        return repository.findAllGaps();
+    }
+
+    @Override
+    public List<BonusPosition> getPositions() {
+        return repository.findAllPositions();
+    }
+
+    @Override
+    public List<BonusSchemeLimit> getSchemeLimits() {
+        return repository.findAllLimits();
+    }
+
+    @Override
+    public List<BonusSchemeLimitView> getSchemeLimitDetails() {
+        return repository.findAllLimitDetails();
+    }
+
+    @Override
+    public BonusSchemeRangeTable getSchemeRangeTable() {
+        return repository.findRangeTable();
+    }
+
+    @Override
+    public List<BonusSchemeBdmLimit> getBdmLimits() {
+        return repository.findAllBdmSchemes();
+    }
+
+    @Override
+    public List<BonusSchemeName> getSchemeNames() {
+        return repository.findAllSchemeNames();
+    }
+
+    @Override
+    public void addScheme(BonusSchemeEntry entry) {
+        if (entry.getDateScheme() == null) {
+            entry.setDateScheme(LocalDate.now());
+        }
+        repository.saveSchemeEntry(entry);
+    }
+}

--- a/src/main/resources/template/bonus-schemes.html
+++ b/src/main/resources/template/bonus-schemes.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Бонусные схемы</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --nav-height: 56px;
+        }
+
+        .navbar {
+            z-index: 1030;
+        }
+
+        .main-content {
+            position: relative;
+            padding-top: var(--nav-height);
+        }
+
+        .table-sticky thead th {
+            position: sticky;
+            top: var(--nav-height);
+            background: #fff;
+            z-index: 1020;
+            border-bottom: 2px solid #dee2e6;
+            box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        .table-bordered > :not(caption) > * > * {
+            border-color: #dee2e6;
+        }
+    </style>
+</head>
+<body>
+<div th:replace="~{navigation :: navi('BonusSchemes')}"></div>
+
+<main class="main-content">
+    <div class="container-fluid mt-4 px-3">
+        <div class="row justify-content-center">
+            <div class="col-12">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-body">
+                        <h3 class="card-title mb-3">Добавить бонусную схему</h3>
+                        <form th:action="@{/bonus-schemes}" th:object="${schemeEntry}" method="post" class="row g-3">
+                            <div class="col-md-3">
+                                <label class="form-label" for="schemeId">Название схемы</label>
+                                <select class="form-select" id="schemeId" th:field="*{schemeId}" required>
+                                    <option value="" disabled selected>Выберите схему</option>
+                                    <option th:each="scheme : ${schemeNames}"
+                                            th:value="${scheme.id}"
+                                            th:text="${scheme.schemeName}"></option>
+                                </select>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label" for="positionId">Должность</label>
+                                <select class="form-select" id="positionId" th:field="*{positionId}" required>
+                                    <option value="" disabled selected>Выберите должность</option>
+                                    <option th:each="position : ${positions}"
+                                            th:value="${position.id}"
+                                            th:text="${position.posName}"></option>
+                                </select>
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label" for="limits">Лимит</label>
+                                <input type="number" step="1" min="0" class="form-control" id="limits" th:field="*{limits}" required>
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label" for="gapId">Процент</label>
+                                <select class="form-select" id="gapId" th:field="*{gapId}" required>
+                                    <option value="" disabled selected>Выберите процент</option>
+                                    <option th:each="gap : ${gaps}"
+                                            th:value="${gap.gapId}"
+                                            th:text="${#numbers.formatDecimal(gap.gapPercent, 0, 'DEFAULT', 0, 'DEFAULT')} + ' %'"></option>
+                                </select>
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label" for="dateScheme">Дата схемы</label>
+                                <input type="date" class="form-control" id="dateScheme" th:field="*{dateScheme}">
+                            </div>
+                            <div class="col-12 d-flex justify-content-end">
+                                <button type="submit" class="btn btn-primary">Сохранить</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <h3 class="card-title mb-3">Бонусные схемы</h3>
+                        <div class="table-responsive">
+                            <table class="table table-striped table-bordered align-middle mb-0 table-sticky">
+                                <thead>
+                                <tr>
+                                    <th th:each="column : ${rangeColumns}" scope="col"
+                                        th:text="${column == 'должность' ? 'Должность' : (column == 'позиция + схема' ? 'Позиция + схема' : (column == 'date_scheme' ? 'Дата' : column))}"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr th:each="row : ${rangeRows}">
+                                    <td th:each="column : ${rangeColumns}"
+                                        th:text="${column == 'date_scheme' ? #dates.format(row[column], 'yyyy-MM-dd') : row[column]}"></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/template/bonus-schemes.html
+++ b/src/main/resources/template/bonus-schemes.html
@@ -9,26 +9,81 @@
             --nav-height: 56px;
         }
 
+        body {
+            padding-top: var(--nav-height);
+        }
+
         .navbar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
             z-index: 1030;
+            height: var(--nav-height);
         }
 
         .main-content {
             position: relative;
-            padding-top: var(--nav-height);
         }
 
+        /* Стили для таблицы - КАК В РАБОЧЕМ ВАРИАНТЕ */
+        .sticky-table-container {
+            max-height: none; /* Убираем ограничение высоты */
+            overflow: visible; /* Убираем скролл */
+        }
+
+        /* Самый простой и надежный вариант */
         .table-sticky thead th {
             position: sticky;
             top: var(--nav-height);
-            background: #fff;
+            background: white !important;
             z-index: 1020;
-            border-bottom: 2px solid #dee2e6;
+            border-bottom: 2px solid #dee2e6 !important;
             box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
         }
 
-        .table-bordered > :not(caption) > * > * {
-            border-color: #dee2e6;
+        .table-sticky {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 0;
+        }
+
+        .table-sticky th,
+        .table-sticky td {
+            border: 1px solid #dee2e6;
+            padding: 8px;
+            text-align: center;
+        }
+
+        /* Стили для первой и второй колонок */
+        .table-sticky th:nth-child(1),
+        .table-sticky td:nth-child(1),
+        .table-sticky th:nth-child(2),
+        .table-sticky td:nth-child(2) {
+            text-align: left;
+            font-weight: bold;
+            background-color: #f8f9fa;
+        }
+
+        /* Стили для карточек */
+        .card {
+            border: 1px solid rgba(0,0,0,.125);
+            border-radius: 0.375rem;
+            margin-bottom: 20px;
+        }
+
+        .card-body {
+            padding: 1.25rem;
+        }
+
+        .card-title {
+            margin-bottom: 1rem;
+            font-weight: bold;
+        }
+        /* Просто убираем жирный у данных в первых двух колонках */
+        .table-sticky td:nth-child(1),
+        .table-sticky td:nth-child(2) {
+            font-weight: normal !important;
         }
     </style>
 </head>
@@ -39,10 +94,12 @@
     <div class="container-fluid mt-4 px-3">
         <div class="row justify-content-center">
             <div class="col-12">
+                <!-- Карточка с формой -->
                 <div class="card mb-4 shadow-sm">
                     <div class="card-body">
                         <h3 class="card-title mb-3">Добавить бонусную схему</h3>
                         <form th:action="@{/bonus-schemes}" th:object="${schemeEntry}" method="post" class="row g-3">
+                            <!-- форма без изменений -->
                             <div class="col-md-3">
                                 <label class="form-label" for="schemeId">Название схемы</label>
                                 <select class="form-select" id="schemeId" th:field="*{schemeId}" required>
@@ -85,30 +142,243 @@
                     </div>
                 </div>
 
+                <!-- Карточка с таблицей -->
                 <div class="card shadow-sm">
                     <div class="card-body">
                         <h3 class="card-title mb-3">Бонусные схемы</h3>
-                        <div class="table-responsive">
-                            <table class="table table-striped table-bordered align-middle mb-0 table-sticky">
-                                <thead>
-                                <tr>
-                                    <th th:each="column : ${rangeColumns}" scope="col"
-                                        th:text="${column == 'должность' ? 'Должность' : (column == 'позиция + схема' ? 'Позиция + схема' : (column == 'date_scheme' ? 'Дата' : column))}"></th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                <tr th:each="row : ${rangeRows}">
-                                    <td th:each="column, iterStat : ${rangeColumns}"
-                                        th:text="${column == 'date_scheme' ? #dates.format(row[iterStat.index], 'yyyy-MM-dd') : row[iterStat.index]}"></td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </div>
+
+                        <!-- ПРОСТО ТАБЛИЦА БЕЗ ОБЕРТОК -->
+                        <table class="table table-bordered table-sticky">
+                            <thead>
+                            <tr>
+                                <th th:each="column : ${rangeColumns}" scope="col"
+                                    th:text="${column == 'должность' ? 'Должность' :
+                                             (column == 'позиция + схема' ? 'Схема' :
+                                             (column == 'date_scheme' ? 'Дата' : column))}"></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr th:each="row : ${rangeRows}">
+                                <td th:each="column, iterStat : ${rangeColumns}"
+                                    th:text="${column == 'date_scheme' ? #dates.format(row[iterStat.index], 'yyyy-MM-dd') :
+                                             row[iterStat.index]}"></td>
+                            </tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             </div>
         </div>
     </div>
 </main>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Функция для установки высоты навигации
+        function setNavHeight() {
+            const nav = document.querySelector('.navbar');
+            if (nav) {
+                const navHeight = nav.offsetHeight;
+                console.log('Высота навигации установлена:', navHeight + 'px');
+                document.documentElement.style.setProperty('--nav-height', navHeight + 'px');
+
+                // Проверяем стили заголовков таблицы
+                const ths = document.querySelectorAll('.table-sticky thead th');
+                ths.forEach((th, i) => {
+                    const style = window.getComputedStyle(th);
+                    console.log(`th[${i}]: position=${style.position}, top=${style.top}`);
+                });
+            }
+        }
+
+        // Устанавливаем высоту несколько раз
+        setNavHeight();
+        setTimeout(setNavHeight, 50);
+        setTimeout(setNavHeight, 200);
+        setTimeout(setNavHeight, 500);
+
+        window.addEventListener('resize', setNavHeight);
+    });
+</script>
 </body>
 </html>
+
+<!--<!DOCTYPE html>-->
+<!--<html xmlns:th="http://www.thymeleaf.org">-->
+<!--<head>-->
+<!--    <meta charset="UTF-8">-->
+<!--    <title>Бонусные схемы</title>-->
+<!--    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">-->
+<!--    <style>-->
+<!--        :root {-->
+<!--            &#45;&#45;nav-height: 56px;-->
+<!--        }-->
+
+<!--        body {-->
+<!--            padding-top: var(&#45;&#45;nav-height); /* Важно! */-->
+<!--        }-->
+
+<!--        .navbar {-->
+<!--            position: fixed; /* Фиксированная навигация */-->
+<!--            top: 0;-->
+<!--            left: 0;-->
+<!--            right: 0;-->
+<!--            z-index: 1030;-->
+<!--            height: var(&#45;&#45;nav-height);-->
+<!--        }-->
+
+<!--        .main-content {-->
+<!--            position: relative;-->
+<!--            margin-top: 0; /* Убираем отступ, т.к. body уже имеет padding-top */-->
+<!--        }-->
+
+<!--        /* Контейнер для таблицы с фиксированной высотой */-->
+<!--        .table-responsive {-->
+<!--            max-height: 70vh;-->
+<!--            overflow-y: auto;-->
+<!--            position: relative;-->
+<!--            border: 1px solid #dee2e6;-->
+<!--            border-radius: 0.375rem;-->
+<!--        }-->
+
+<!--        /* Стиль для прилипающей шапки таблицы */-->
+<!--        .table-sticky thead th {-->
+<!--            position: sticky;-->
+<!--            top: 0; /* Прилипает к верху контейнера .table-responsive */-->
+<!--            background: white;-->
+<!--            z-index: 10;-->
+<!--            border-bottom: 2px solid #dee2e6 !important;-->
+<!--            box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);-->
+<!--        }-->
+
+<!--        /* Убираем стандартные отступы у таблицы */-->
+<!--        .table-sticky {-->
+<!--            margin-bottom: 0;-->
+<!--            border-collapse: separate;-->
+<!--            border-spacing: 0;-->
+<!--        }-->
+
+<!--        /* Стили для карточек */-->
+<!--        .card {-->
+<!--            border: 1px solid rgba(0,0,0,.125);-->
+<!--            border-radius: 0.375rem;-->
+<!--            margin-bottom: 20px;-->
+<!--        }-->
+
+<!--        .card-body {-->
+<!--            padding: 1.25rem;-->
+<!--        }-->
+
+<!--        .card-title {-->
+<!--            margin-bottom: 1rem;-->
+<!--            font-weight: bold;-->
+<!--        }-->
+<!--    </style>-->
+<!--</head>-->
+<!--<body>-->
+<!--<div th:replace="~{navigation :: navi('BonusSchemes')}"></div>-->
+
+<!--<main class="main-content">-->
+<!--    <div class="container-fluid mt-4 px-3">-->
+<!--        <div class="row justify-content-center">-->
+<!--            <div class="col-12">-->
+<!--                <div class="card mb-4 shadow-sm">-->
+<!--                    <div class="card-body">-->
+<!--                        <h3 class="card-title mb-3">Добавить бонусную схему</h3>-->
+<!--                        <form th:action="@{/bonus-schemes}" th:object="${schemeEntry}" method="post" class="row g-3">-->
+<!--                            <div class="col-md-3">-->
+<!--                                <label class="form-label" for="schemeId">Название схемы</label>-->
+<!--                                <select class="form-select" id="schemeId" th:field="*{schemeId}" required>-->
+<!--                                    <option value="" disabled selected>Выберите схему</option>-->
+<!--                                    <option th:each="scheme : ${schemeNames}"-->
+<!--                                            th:value="${scheme.id}"-->
+<!--                                            th:text="${scheme.schemeName}"></option>-->
+<!--                                </select>-->
+<!--                            </div>-->
+<!--                            <div class="col-md-3">-->
+<!--                                <label class="form-label" for="positionId">Должность</label>-->
+<!--                                <select class="form-select" id="positionId" th:field="*{positionId}" required>-->
+<!--                                    <option value="" disabled selected>Выберите должность</option>-->
+<!--                                    <option th:each="position : ${positions}"-->
+<!--                                            th:value="${position.id}"-->
+<!--                                            th:text="${position.posName}"></option>-->
+<!--                                </select>-->
+<!--                            </div>-->
+<!--                            <div class="col-md-2">-->
+<!--                                <label class="form-label" for="limits">Лимит</label>-->
+<!--                                <input type="number" step="1" min="0" class="form-control" id="limits" th:field="*{limits}" required>-->
+<!--                            </div>-->
+<!--                            <div class="col-md-2">-->
+<!--                                <label class="form-label" for="gapId">Процент</label>-->
+<!--                                <select class="form-select" id="gapId" th:field="*{gapId}" required>-->
+<!--                                    <option value="" disabled selected>Выберите процент</option>-->
+<!--                                    <option th:each="gap : ${gaps}"-->
+<!--                                            th:value="${gap.gapId}"-->
+<!--                                            th:text="${#numbers.formatDecimal(gap.gapPercent, 0, 'DEFAULT', 0, 'DEFAULT')} + ' %'"></option>-->
+<!--                                </select>-->
+<!--                            </div>-->
+<!--                            <div class="col-md-2">-->
+<!--                                <label class="form-label" for="dateScheme">Дата схемы</label>-->
+<!--                                <input type="date" class="form-control" id="dateScheme" th:field="*{dateScheme}">-->
+<!--                            </div>-->
+<!--                            <div class="col-12 d-flex justify-content-end">-->
+<!--                                <button type="submit" class="btn btn-primary">Сохранить</button>-->
+<!--                            </div>-->
+<!--                        </form>-->
+<!--                    </div>-->
+<!--                </div>-->
+
+<!--                <div class="card shadow-sm">-->
+<!--                    <div class="card-body">-->
+<!--                        <h3 class="card-title mb-3">Бонусные схемы</h3>-->
+
+<!--                        &lt;!&ndash; Контейнер с фиксированной высотой для скролла &ndash;&gt;-->
+<!--                        <div class="table-responsive">-->
+<!--                            <table class="table table-striped table-bordered align-middle mb-0 table-sticky">-->
+<!--                                <thead>-->
+<!--                                <tr>-->
+<!--                                    <th th:each="column : ${rangeColumns}" scope="col"-->
+<!--                                        th:text="${column == 'должность' ? 'Должность' :-->
+<!--                                                 (column == 'позиция + схема' ? 'Схема' :-->
+<!--                                                 (column == 'date_scheme' ? 'Дата' : column))}"></th>-->
+<!--                                </tr>-->
+<!--                                </thead>-->
+<!--                                <tbody>-->
+<!--                                <tr th:each="row : ${rangeRows}">-->
+<!--                                    <td th:each="column, iterStat : ${rangeColumns}"-->
+<!--                                        th:text="${column == 'date_scheme' ? #dates.format(row[iterStat.index], 'yyyy-MM-dd') :-->
+<!--                                                 (iterStat.index > 1 ? row[iterStat.index] : row[iterStat.index])}"></td>-->
+<!--                                </tr>-->
+<!--                                </tbody>-->
+<!--                            </table>-->
+<!--                        </div>-->
+<!--                    </div>-->
+<!--                </div>-->
+<!--            </div>-->
+<!--        </div>-->
+<!--    </div>-->
+<!--</main>-->
+
+<!--<script>-->
+<!--    document.addEventListener('DOMContentLoaded', function() {-->
+<!--        // Динамически вычисляем высоту навигации-->
+<!--        function updateNavHeight() {-->
+<!--            const nav = document.querySelector('.navbar');-->
+<!--            if (nav) {-->
+<!--                const navHeight = nav.offsetHeight;-->
+<!--                console.log('Высота навигации:', navHeight);-->
+<!--                document.documentElement.style.setProperty('&#45;&#45;nav-height', navHeight + 'px');-->
+<!--            }-->
+<!--        }-->
+
+<!--        // Обновляем высоту при загрузке и изменении размера-->
+<!--        updateNavHeight();-->
+<!--        window.addEventListener('resize', updateNavHeight);-->
+<!--        window.addEventListener('load', updateNavHeight);-->
+
+<!--        // Небольшая задержка для гарантии-->
+<!--        setTimeout(updateNavHeight, 300);-->
+<!--    });-->
+<!--</script>-->
+<!--</body>-->
+<!--</html>-->

--- a/src/main/resources/template/bonus-schemes.html
+++ b/src/main/resources/template/bonus-schemes.html
@@ -98,8 +98,8 @@
                                 </thead>
                                 <tbody>
                                 <tr th:each="row : ${rangeRows}">
-                                    <td th:each="column : ${rangeColumns}"
-                                        th:text="${column == 'date_scheme' ? #dates.format(row[column], 'yyyy-MM-dd') : row[column]}"></td>
+                                    <td th:each="column, iterStat : ${rangeColumns}"
+                                        th:text="${column == 'date_scheme' ? #dates.format(row[iterStat.index], 'yyyy-MM-dd') : row[iterStat.index]}"></td>
                                 </tr>
                                 </tbody>
                             </table>

--- a/src/main/resources/template/navigation.html
+++ b/src/main/resources/template/navigation.html
@@ -102,9 +102,11 @@
                 <li class="nav-item" th:classappend="${activeTab} == 'Margin' ? 'active'">
                     <a class="nav-link" th:href="@{/margin}">Маржинальная прибыль</a>
                 </li>
+                <li class="nav-item" th:classappend="${activeTab} == 'BonusSchemes' ? 'active'">
+                    <a class="nav-link" th:href="@{/bonus-schemes}">Бонусные схемы</a>
+                </li>
             </ul>
         </div>
-<
     </nav>
     <div class="visible-md" style="height:80px;"></div>
 </div>


### PR DESCRIPTION
## Summary
- consume the stored procedure output for bonus scheme ranges and expose dynamic columns and rows to the controller
- add a DTO to carry range table headers and data while preserving the add-scheme form inputs
- rebuild the Thymeleaf table to render procedure-driven headers and values, formatting dates inline

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ed5c6923483219c341e33787eadaa)