### PR TITLE
Add department and employee selections to act modal

### DIFF
--- a/src/main/java/ru/alta/thirdproj/controllers/MarginController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/MarginController.java
@@ -33,6 +33,8 @@ public class MarginController {
     private MarginBonusServiceImpl marginBonusService;
     private UserSalesServiceImpl userSalesService;
     private UserService userService;
+    private DepartmentService departmentService;
+    private EmployeesService employeesService;
 
     private EmailUserSendConfiguration emailUserSendConfiguration;
     private EmailPaymentSuccessService emailPaymentSuccessService;
@@ -41,13 +43,17 @@ public class MarginController {
     public void setUserSalaryService(UserSalaryServiceImpl userSalaryService, MarginBonusServiceImpl marginBonusService,
                                      UserSalesServiceImpl userSalesService, UserService userService,
                                      EmailUserSendConfiguration emailUserSendConfiguration,
-                                     EmailPaymentSuccessService emailPaymentSuccessService){
+                                     EmailPaymentSuccessService emailPaymentSuccessService,
+                                     DepartmentService departmentService,
+                                     EmployeesService employeesService){
         this.userSalaryService = userSalaryService;
         this.marginBonusService = marginBonusService;
         this.userSalesService = userSalesService;
         this.userService = userService;
         this.emailUserSendConfiguration = emailUserSendConfiguration;
         this.emailPaymentSuccessService = emailPaymentSuccessService;
+        this.departmentService = departmentService;
+        this.employeesService = employeesService;
     }
 
 
@@ -187,6 +193,18 @@ public class MarginController {
         model.addAttribute("actByUserList", actByUserList != null ? actByUserList : Collections.emptyList());
 
         return "actByUserCheck :: actByUserTab";
+    }
+
+    @GetMapping("/userAct/departments")
+    @ResponseBody
+    public List<Department> getDepartments() {
+        return departmentService.getDepartments();
+    }
+
+    @GetMapping("/userAct/employees")
+    @ResponseBody
+    public List<Employees> getEmployees() {
+        return employeesService.getActiveEmployeesForPlanMonth();
     }
 
     @PostMapping("/userAct/update")

--- a/src/main/java/ru/alta/thirdproj/entites/Employees.java
+++ b/src/main/java/ru/alta/thirdproj/entites/Employees.java
@@ -1,0 +1,9 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+@Data
+public class Employees {
+    private int manId;
+    private String manFIO;
+}

--- a/src/main/java/ru/alta/thirdproj/repositories/UserSalaryRepImplRep.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/UserSalaryRepImplRep.java
@@ -116,6 +116,13 @@ public class UserSalaryRepImplRep  {
                     "LEFT JOIN dbo.project p ON p.project_id = ab.project_id\n" +
                     "WHERE CONVERT(date, ab.date_act) BETWEEN :date1 AND :date2\n" +
                     "  AND NOT EXISTS (SELECT 1 FROM project_buh_failed_probation_period fp WHERE fp.act_id = ab.id);";
+    private static final String SELECT_EMPLOYEES_FOR_PLAN_MONTH =
+            "select m.man_fio, m.man_id from login l " +
+                    "join man m on m.man_id = l.login_user_id " +
+                    "join userplanByMonth ubm on ubm.user_id = m.man_id " +
+                    "where l.login_active=1 " +
+                    "and ubm.userplan_year = datepart(yy, getdate()) and ubm.userplan_month =  datepart(mm, getdate()) " +
+                    "order by m.man_fio";
     private static final String SELECT_DEPARTMENTS_QUERY =
             "SELECT DISTINCT id, dep_name FROM depatment WHERE dep_name IS NOT NULL " +
                     "and id not in (5,9,7,10) ORDER BY dep_name";
@@ -499,6 +506,27 @@ public class UserSalaryRepImplRep  {
         }
     }
 
+    public List<Employees> getEmployeesForCurrentPlanMonth() {
+        try (Connection connection = sql2o.open()) {
+            Table table = connection.createQuery(SELECT_EMPLOYEES_FOR_PLAN_MONTH, false)
+                    .executeAndFetchTable();
+
+            if (table == null) {
+                return Collections.emptyList();
+            }
+
+            Map<Integer, Employees> employees = new LinkedHashMap<>();
+            for (Map<String, Object> row : table.asList()) {
+                Employees employee = mapRowToEmployee(row);
+                if (employee != null) {
+                    employees.putIfAbsent(employee.getManId(), employee);
+                }
+            }
+
+            return new ArrayList<>(employees.values());
+        }
+    }
+
     private Department mapRowToDepartment(Map<String, Object> row) {
         if (row == null || row.isEmpty()) {
             return null;
@@ -520,6 +548,24 @@ public class UserSalaryRepImplRep  {
         }
 
         return department;
+    }
+
+    private Employees mapRowToEmployee(Map<String, Object> row) {
+        if (row == null || row.isEmpty()) {
+            return null;
+        }
+
+        Integer manId = extractInteger(row.get("man_id"));
+        Object fioValue = row.get("man_fio");
+
+        if (manId == null || fioValue == null) {
+            return null;
+        }
+
+        Employees employee = new Employees();
+        employee.setManId(manId);
+        employee.setManFIO(fioValue.toString());
+        return employee;
     }
 
     private Integer extractInteger(Object value) {

--- a/src/main/java/ru/alta/thirdproj/services/EmployeesService.java
+++ b/src/main/java/ru/alta/thirdproj/services/EmployeesService.java
@@ -1,0 +1,25 @@
+package ru.alta.thirdproj.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.alta.thirdproj.entites.Employees;
+import ru.alta.thirdproj.repositories.UserSalaryRepImplRep;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class EmployeesService {
+
+    private final UserSalaryRepImplRep userSalaryRepImplRep;
+
+    @Autowired
+    public EmployeesService(UserSalaryRepImplRep userSalaryRepImplRep) {
+        this.userSalaryRepImplRep = userSalaryRepImplRep;
+    }
+
+    public List<Employees> getActiveEmployeesForPlanMonth() {
+        List<Employees> employees = userSalaryRepImplRep.getEmployeesForCurrentPlanMonth();
+        return employees != null ? Collections.unmodifiableList(employees) : Collections.emptyList();
+    }
+}

--- a/src/main/resources/template/actByUserCheck.html
+++ b/src/main/resources/template/actByUserCheck.html
@@ -94,10 +94,10 @@
                             <td th:text="${#numbers.formatDecimal(act.summResecher, 1, 2)}"></td>
                             <td>
                                 <span th:if="${act.responsibleUserName != null}"
-                                      th:text="${#numbers.formatDecimal(act.candidatePercent, 1, 2)} + '%'">
+                                      th:text="${#numbers.formatDecimal(act.percentResponsibleUserComplicity, 1, 2)} + '%'">
                                 </span>
                                 <span th:if="${act.responsibleUserName == null}"
-                                      th:text="${#numbers.formatDecimal(act.resecherPercent, 1, 2)} + '%'">
+                                      th:text="${#numbers.formatDecimal(act.percentResecherComplicity, 1, 2)} + '%'">
                                 </span>
                             </td>
                             <td th:text="${act.projectName}"></td>

--- a/src/main/resources/template/actByUserCheck.html
+++ b/src/main/resources/template/actByUserCheck.html
@@ -131,8 +131,8 @@
                     <h5 class="modal-title" id="editActModalLabel">Изменить данные акта</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body bg-white">
-                    <form id="editActForm">
+                <form id="editActForm">
+                    <div class="modal-body bg-white">
                         <input type="hidden" id="editActId" />
                         <div class="row g-3">
                             <div class="col-md-6">
@@ -170,22 +170,21 @@
                             <p class="text-muted small mb-2">Выберите ФИО и направление для каждого ресечера.</p>
                             <div id="researchersContainer" class="participant-list"></div>
                         </div>
-                        </div>
-                    </form>
-                    <div class="alert alert-danger mt-3 d-none" id="editActError"></div>
-                    <div class="alert alert-success mt-3 d-none" id="editActSuccess">Данные сохранены</div>
-                </div>
-                <div class="modal-footer bg-white">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+                        <div class="alert alert-danger mt-3 d-none" id="editActError"></div>
+                        <div class="alert alert-success mt-3 d-none" id="editActSuccess">Данные сохранены</div>
+                    </div>
+                    <div class="modal-footer bg-white">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
 
-                    <!-- Тип submit, чтобы гарантированно срабатывал слушатель form.submit -->
-                    <button type="submit"
-                            class="btn btn-primary"
-                            id="editActSaveBtn">
-                        Сохранить
-                    </button>
-                </div>
-
+                        <!-- Тип submit, чтобы гарантированно срабатывал слушатель form.submit -->
+                        <button type="submit"
+                                class="btn btn-primary"
+                                id="editActSaveBtn">
+                            Сохранить
+                        </button>
+                    </div>
+                </form>
+                
         </div>
         </div>
     </div>

--- a/src/main/resources/template/actByUserCheck.html
+++ b/src/main/resources/template/actByUserCheck.html
@@ -151,10 +151,6 @@
                                 <label for="editCandidate" class="form-label">Кандидат</label>
                                 <input type="text" class="form-control" id="editCandidate" required />
                             </div>
-                            <div class="col-md-6">
-                                <label for="editDepartment" class="form-label">Направление</label>
-                                <input type="text" class="form-control" id="editDepartment" required />
-                            </div>
                         </div>
 
                         <div class="mt-4">
@@ -162,6 +158,7 @@
                                 <h6 class="mb-0">Консультанты</h6>
                                 <button type="button" class="btn btn-outline-primary btn-sm" id="addConsultantBtn">Добавить консультанта</button>
                             </div>
+                            <p class="text-muted small mb-2">Выберите ФИО и направление для каждого консультанта.</p>
                             <div id="consultantsContainer" class="participant-list"></div>
                         </div>
 
@@ -170,6 +167,7 @@
                                 <h6 class="mb-0">Ресечеры</h6>
                                 <button type="button" class="btn btn-outline-primary btn-sm" id="addResearcherBtn">Добавить ресечера</button>
                             </div>
+                            <p class="text-muted small mb-2">Выберите ФИО и направление для каждого ресечера.</p>
                             <div id="researchersContainer" class="participant-list"></div>
                         </div>
                         </div>

--- a/src/main/resources/template/margin.html
+++ b/src/main/resources/template/margin.html
@@ -1238,29 +1238,32 @@
 
     // ---------- ОБРАБОТКА SUBMIT И КНОПКИ "СОХРАНИТЬ" ----------
 
-    const form = document.getElementById('editActForm');
-    const saveBtn = document.getElementById('editActSaveBtn');
+    container.addEventListener('submit', async (event) => {
+        const form = event.target;
+        if (form?.id !== 'editActForm') {
+            return;
+        }
 
-    
+        event.preventDefault();
+        await submitActUpdate();
+    });
 
-    if (form) {
-        form.addEventListener('submit', async (event) => {
-            event.preventDefault();
-            
+    container.addEventListener('click', async (event) => {
+        const saveBtn = event.target?.closest('#editActSaveBtn');
+        if (!saveBtn) {
+            return;
+        }
+
+        event.preventDefault();
+        saveBtn.disabled = true;
+        saveBtn.style.pointerEvents = 'none';
+        try {
             await submitActUpdate();
-        });
-    }
-
-    // Прямой клик по кнопке — вызываем сохранение (без дополнительных дублей)
-    if (saveBtn) {
-        saveBtn.disabled = false;
-        saveBtn.style.pointerEvents = 'auto';
-        saveBtn.addEventListener('click', async (event) => {
-            event.preventDefault();
-
-            await submitActUpdate();
-        }, { capture: true });
-    }
+        } finally {
+            saveBtn.disabled = false;
+            saveBtn.style.pointerEvents = 'auto';
+        }
+    }, { capture: true });
 
         // ---------- ДОБАВЛЕНИЕ / УДАЛЕНИЕ УЧАСТНИКОВ ----------
 

--- a/src/main/resources/template/margin.html
+++ b/src/main/resources/template/margin.html
@@ -862,28 +862,103 @@
             return;
         }
 
-    
+
 
         // ---------- ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ ДЛЯ СТРОК УЧАСТНИКОВ ----------
+        let cachedEmployees = [];
+        let cachedDepartments = [];
+        let referenceDataPromise = null;
+
+        async function loadReferenceData() {
+            if (!referenceDataPromise) {
+                referenceDataPromise = Promise.all([
+                    fetch('/userAct/employees').then(r => r.ok ? r.json() : []),
+                    fetch('/userAct/departments').then(r => r.ok ? r.json() : [])
+                ]).then(([employees, departments]) => {
+                    cachedEmployees = Array.isArray(employees) ? employees : [];
+                    cachedDepartments = Array.isArray(departments) ? departments : [];
+                    return { employees: cachedEmployees, departments: cachedDepartments };
+                }).catch(err => {
+                    console.error('[UpdateAct] Failed to load reference data', err);
+                    cachedEmployees = [];
+                    cachedDepartments = [];
+                    return { employees: [], departments: [] };
+                });
+            }
+
+            return referenceDataPromise;
+        }
+
+        function buildOptions(list, valueKey, labelKey, selectedValue, placeholderLabel, fallbackLabel) {
+            const options = [
+                `<option value="">${placeholderLabel}</option>`
+            ];
+
+            let hasSelected = false;
+
+            list.forEach(item => {
+                const value = item?.[valueKey];
+                const label = item?.[labelKey];
+
+                if (value === undefined || label === undefined) {
+                    return;
+                }
+
+                const isSelected = selectedValue !== undefined && selectedValue !== null && String(selectedValue) === String(value);
+                if (isSelected) {
+                    hasSelected = true;
+                }
+                options.push(`<option value="${value}" ${isSelected ? 'selected' : ''}>${label}</option>`);
+            });
+
+            if (!hasSelected && fallbackLabel) {
+                options.push(`<option value="${selectedValue ?? ''}" selected>${fallbackLabel}</option>`);
+            }
+
+            return options.join('');
+        }
 
         function createConsultantRow(data = {}) {
             const row = document.createElement('div');
             row.className = 'row g-2 align-items-end consultant-row mb-2';
+
+            const employeeOptions = buildOptions(
+                cachedEmployees,
+                'manId',
+                'manFIO',
+                data.id,
+                'ФИО консультанта',
+                data.name
+            );
+
+            const departmentOptions = buildOptions(
+                cachedDepartments,
+                'id',
+                'name',
+                data.departmentId,
+                'Направление',
+                data.department
+            );
+
             row.innerHTML = `
-                <div class="col-md-4">
-                    <input type="text"
-                           class="form-control consultant-name"
-                           placeholder="ФИО консультанта"
-                           value="${data.name || ''}">
+                <div class="col-md-3">
+                    <select class="form-select consultant-name" aria-label="ФИО консультанта">
+                        ${employeeOptions}
+                    </select>
                 </div>
                 <div class="col-md-3">
+                    <select class="form-select consultant-department" aria-label="Направление консультанта">
+                        ${departmentOptions}
+                    </select>
+                </div>
+                <div class="col-md-2">
                     <input type="number"
                            step="0.01"
                            class="form-control consultant-sum"
                            placeholder="Сумма"
                            value="${data.sum ?? ''}">
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <input type="number"
                            step="0.01"
                            class="form-control consultant-percent"
@@ -896,15 +971,6 @@
                         Удалить
                     </button>
                 </div>
-                <input type="hidden"
-                       class="consultant-department"
-                       value="${data.department || ''}">
-                <input type="hidden"
-                       class="consultant-id"
-                       value="${data.id ?? ''}">
-                <input type="hidden"
-                       class="consultant-department-id"
-                       value="${data.departmentId ?? ''}">
                 <input type="hidden"
                        class="consultant-complicity"
                        value="${data.complicity ?? ''}">
@@ -927,21 +993,44 @@
         function createResearcherRow(data = {}) {
             const row = document.createElement('div');
             row.className = 'row g-2 align-items-end researcher-row mb-2';
+
+            const employeeOptions = buildOptions(
+                cachedEmployees,
+                'manId',
+                'manFIO',
+                data.id,
+                'ФИО ресечера',
+                data.name
+            );
+
+            const departmentOptions = buildOptions(
+                cachedDepartments,
+                'id',
+                'name',
+                data.departmentId,
+                'Направление',
+                data.department
+            );
+
             row.innerHTML = `
-                <div class="col-md-4">
-                    <input type="text"
-                           class="form-control researcher-name"
-                           placeholder="ФИО ресечера"
-                           value="${data.name || ''}">
+                <div class="col-md-3">
+                    <select class="form-select researcher-name" aria-label="ФИО ресечера">
+                        ${employeeOptions}
+                    </select>
                 </div>
                 <div class="col-md-3">
+                    <select class="form-select researcher-department" aria-label="Направление ресечера">
+                        ${departmentOptions}
+                    </select>
+                </div>
+                <div class="col-md-2">
                     <input type="number"
                            step="0.01"
                            class="form-control researcher-sum"
                            placeholder="Сумма"
                            value="${data.sum ?? ''}">
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <input type="number"
                            step="0.01"
                            class="form-control researcher-percent"
@@ -954,15 +1043,6 @@
                         Удалить
                     </button>
                 </div>
-                <input type="hidden"
-                       class="researcher-department"
-                       value="${data.department || ''}">
-                <input type="hidden"
-                       class="researcher-department-id"
-                       value="${data.departmentId ?? ''}">
-                <input type="hidden"
-                       class="researcher-id"
-                       value="${data.id ?? ''}">
                 <input type="hidden"
                        class="researcher-complicity"
                        value="${data.complicity ?? ''}">
@@ -984,7 +1064,7 @@
 
         // ---------- ОТКРЫТИЕ МОДАЛКИ ПО КНОПКЕ "ИЗМЕНИТЬ" ----------
 
-        container.addEventListener('click', (event) => {
+        container.addEventListener('click', async (event) => {
             try {
                 const editBtn = event.target.closest('.edit-act-btn');
                 if (!editBtn) return;
@@ -1009,6 +1089,8 @@
                     return;
                 }
 
+            await loadReferenceData();
+
             // Заполняем основные поля из data-* атрибутов первой строки группы
             const setValue = (id, value) => {
                 const el = document.getElementById(id);
@@ -1020,7 +1102,6 @@
             setValue('editActDate', row.dataset.actDate);
             setValue('editTotalNoNds', row.dataset.total);
             setValue('editCandidate', row.dataset.candidate);
-            setValue('editDepartment', row.dataset.department);
 
             // Очищаем старых участников
             consultantsContainer.innerHTML = '';
@@ -1177,15 +1258,17 @@
 
         // ---------- ДОБАВЛЕНИЕ / УДАЛЕНИЕ УЧАСТНИКОВ ----------
 
-        container.addEventListener('click', (event) => {
+        container.addEventListener('click', async (event) => {
             if (event.target?.id === 'addConsultantBtn') {
                 event.preventDefault();
+                await loadReferenceData();
                 const list = document.getElementById('consultantsContainer');
                 if (list) list.appendChild(createConsultantRow());
             }
 
             if (event.target?.id === 'addResearcherBtn') {
                 event.preventDefault();
+                await loadReferenceData();
                 const list = document.getElementById('researchersContainer');
                 if (list) list.appendChild(createResearcherRow());
             }
@@ -1213,24 +1296,29 @@
     errorAlert.classList.add('d-none');
     successAlert.classList.add('d-none');
 
+
     const payload = {
         actId: parseInt(document.getElementById('editActId')?.value || '0', 10),
         totalNoNds: parseFloat(document.getElementById('editTotalNoNds')?.value || '0'),
         candidate: document.getElementById('editCandidate')?.value || '',
-        departmentName: document.getElementById('editDepartment')?.value || '',
         participants: []
     };
 
-    const defaultDepartment = document.getElementById('editDepartment')?.value || '';
-
     const consultants = Array.from(document.querySelectorAll('.consultant-row'))
         .map(row => {
-            const name = row.querySelector('.consultant-name')?.value?.trim() || '';
+            const consultantSelect = row.querySelector('.consultant-name');
+            const consultantDeptSelect = row.querySelector('.consultant-department');
+
+            const name = consultantSelect?.value
+                ? consultantSelect.selectedOptions[0]?.textContent.trim() || ''
+                : '';
             const sumVal = parseFloat(row.querySelector('.consultant-sum')?.value || '');
             const percentVal = parseFloat(row.querySelector('.consultant-percent')?.value || '');
-            const department = row.querySelector('.consultant-department')?.value || defaultDepartment;
-            const departmentId = parseInt(row.querySelector('.consultant-department-id')?.value || '', 10);
-            const responsibleUserId = parseInt(row.querySelector('.consultant-id')?.value || '', 10);
+            const department = consultantDeptSelect?.value
+                ? consultantDeptSelect.selectedOptions[0]?.textContent.trim() || ''
+                : '';
+            const departmentId = parseInt(consultantDeptSelect?.value || '', 10);
+            const responsibleUserId = parseInt(consultantSelect?.value || '', 10);
             const complicity = parseFloat(row.querySelector('.consultant-complicity')?.value || '');
             const leader = row.querySelector('.consultant-leader')?.value || '';
             const leaderId = parseInt(row.querySelector('.consultant-leader-id')?.value || '', 10);
@@ -1243,12 +1331,19 @@
 
     const researchers = Array.from(document.querySelectorAll('.researcher-row'))
         .map(row => {
-            const name = row.querySelector('.researcher-name')?.value?.trim() || '';
+            const researcherSelect = row.querySelector('.researcher-name');
+            const researcherDeptSelect = row.querySelector('.researcher-department');
+
+            const name = researcherSelect?.value
+                ? researcherSelect.selectedOptions[0]?.textContent.trim() || ''
+                : '';
             const sumVal = parseFloat(row.querySelector('.researcher-sum')?.value || '');
             const percentVal = parseFloat(row.querySelector('.researcher-percent')?.value || '');
-            const department = row.querySelector('.researcher-department')?.value || defaultDepartment;
-            const departmentId = parseInt(row.querySelector('.researcher-department-id')?.value || '', 10);
-            const researcherId = parseInt(row.querySelector('.researcher-id')?.value || '', 10);
+            const department = researcherDeptSelect?.value
+                ? researcherDeptSelect.selectedOptions[0]?.textContent.trim() || ''
+                : '';
+            const departmentId = parseInt(researcherDeptSelect?.value || '', 10);
+            const researcherId = parseInt(researcherSelect?.value || '', 10);
             const complicity = parseFloat(row.querySelector('.researcher-complicity')?.value || '');
             const leader = row.querySelector('.researcher-leader')?.value || '';
             const leaderId = parseInt(row.querySelector('.researcher-leader-id')?.value || '', 10);
@@ -1259,6 +1354,16 @@
         })
         .filter(item => item.name || Number.isFinite(item.sumVal) || Number.isFinite(item.percentVal));
 
+    payload.departmentName = consultants[0]?.department || researchers[0]?.department || '';
+    payload.departmentId = Number.isFinite(consultants[0]?.departmentId)
+        ? consultants[0].departmentId
+        : (Number.isFinite(researchers[0]?.departmentId) ? researchers[0].departmentId : null);
+    payload.resecherDepartmentName = researchers[0]?.department || '';
+    payload.depatmentResecherId = Number.isFinite(researchers[0]?.departmentId) ? researchers[0].departmentId : null;
+    const fallbackConsultantDepartment = payload.departmentName || '';
+    const fallbackConsultantDepartmentId = payload.departmentId ?? null;
+    const fallbackResearcherDepartment = payload.resecherDepartmentName || payload.departmentName || '';
+    const fallbackResearcherDepartmentId = payload.depatmentResecherId ?? payload.departmentId ?? null;
     const maxParticipants = Math.max(consultants.length, researchers.length);
 
     for (let i = 0; i < maxParticipants; i++) {
@@ -1276,8 +1381,8 @@
             responsibleUserId: Number.isFinite(consultant.responsibleUserId) ? consultant.responsibleUserId : null,
             summResponsibleUser: Number.isFinite(consultant.sumVal) ? consultant.sumVal : null,
             candidatePercent: Number.isFinite(consultant.percentVal) ? consultant.percentVal : null,
-            departmentName: consultant.department || defaultDepartment,
-            departmentId: Number.isFinite(consultant.departmentId) ? consultant.departmentId : null,
+            departmentName: consultant.department || fallbackConsultantDepartment,
+            departmentId: Number.isFinite(consultant.departmentId) ? consultant.departmentId : fallbackConsultantDepartmentId,
             percentResponsibleUserComplicity: Number.isFinite(consultant.complicity) ? consultant.complicity : null,
             teameLeaderName: consultant.leader || null,
             teameLeaderId: Number.isFinite(consultant.leaderId) ? consultant.leaderId : null,
@@ -1287,8 +1392,8 @@
             resecherId: Number.isFinite(researcher.researcherId) ? researcher.researcherId : null,
             summResecher: Number.isFinite(researcher.sumVal) ? researcher.sumVal : null,
             resecherPercent: Number.isFinite(researcher.percentVal) ? researcher.percentVal : null,
-            resecherDepartmentName: researcher.department || defaultDepartment,
-            depatmentResecherId: Number.isFinite(researcher.departmentId) ? researcher.departmentId : null,
+            resecherDepartmentName: researcher.department || fallbackResearcherDepartment,
+            depatmentResecherId: Number.isFinite(researcher.departmentId) ? researcher.departmentId : fallbackResearcherDepartmentId,
             percentResecherComplicity: Number.isFinite(researcher.complicity) ? researcher.complicity : null
         });
     }

--- a/src/main/resources/template/margin.html
+++ b/src/main/resources/template/margin.html
@@ -862,6 +862,12 @@
             return;
         }
 
+        // Предотвращаем повторную инициализацию, чтобы события не срабатывали дважды
+        if (container.dataset.actEditInitialized === 'true') {
+            return;
+        }
+        container.dataset.actEditInitialized = 'true';
+
 
 
         // ---------- ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ ДЛЯ СТРОК УЧАСТНИКОВ ----------
@@ -1251,7 +1257,7 @@
         saveBtn.style.pointerEvents = 'auto';
         saveBtn.addEventListener('click', async (event) => {
             event.preventDefault();
-            
+
             await submitActUpdate();
         }, { capture: true });
     }

--- a/src/main/resources/template/margin.html
+++ b/src/main/resources/template/margin.html
@@ -1238,32 +1238,37 @@
 
     // ---------- ОБРАБОТКА SUBMIT И КНОПКИ "СОХРАНИТЬ" ----------
 
-    container.addEventListener('submit', async (event) => {
-        const form = event.target;
-        if (form?.id !== 'editActForm') {
-            return;
-        }
+    const modalElement = document.getElementById('editActModal');
+    if (modalElement && !modalElement.dataset.handlersAttached) {
+        modalElement.dataset.handlersAttached = 'true';
 
-        event.preventDefault();
-        await submitActUpdate();
-    });
+        document.addEventListener('submit', async (event) => {
+            const form = event.target;
+            if (form?.id !== 'editActForm') {
+                return;
+            }
 
-    container.addEventListener('click', async (event) => {
-        const saveBtn = event.target?.closest('#editActSaveBtn');
-        if (!saveBtn) {
-            return;
-        }
-
-        event.preventDefault();
-        saveBtn.disabled = true;
-        saveBtn.style.pointerEvents = 'none';
-        try {
+            event.preventDefault();
             await submitActUpdate();
-        } finally {
-            saveBtn.disabled = false;
-            saveBtn.style.pointerEvents = 'auto';
-        }
-    }, { capture: true });
+        });
+
+        document.addEventListener('click', async (event) => {
+            const saveBtn = event.target?.closest('#editActSaveBtn');
+            if (!saveBtn) {
+                return;
+            }
+
+            event.preventDefault();
+            saveBtn.disabled = true;
+            saveBtn.style.pointerEvents = 'none';
+            try {
+                await submitActUpdate();
+            } finally {
+                saveBtn.disabled = false;
+                saveBtn.style.pointerEvents = 'auto';
+            }
+        }, { capture: true });
+    }
 
         // ---------- ДОБАВЛЕНИЕ / УДАЛЕНИЕ УЧАСТНИКОВ ----------
 


### PR DESCRIPTION
## Summary
- add API support and data models to expose active employees and available departments
- update the act editing modal to use dropdowns for consultant and researcher names and directions
- send selected IDs for consultants, researchers, and their departments when updating acts

## Testing
- ./mvnw test *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bdb67fce883218042ee0adb4a8b62)