### PR TITLE
Refine probation act save service

### DIFF
--- a/src/main/java/ru/alta/thirdproj/services/MarginBonusServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/MarginBonusServiceImpl.java
@@ -2,22 +2,23 @@ package ru.alta.thirdproj.services;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ru.alta.thirdproj.entites.ActByUserCheck;
 import ru.alta.thirdproj.entites.MarginBonusBDM;
 import ru.alta.thirdproj.entites.UserSalary;
 import ru.alta.thirdproj.entites.UserSalaryDetail;
-import ru.alta.thirdproj.repositories.UserBonusKPIRepositoryImpl;
 import ru.alta.thirdproj.repositories.UserSalaryRepImplRep;
 
 import java.time.LocalDate;
 import java.util.List;
+
 @Service
 public class MarginBonusServiceImpl implements iMarginBonusService {
 
-    private UserSalaryRepImplRep userSalaryRepImplRep;
+    private final UserSalaryRepImplRep userSalaryRepImplRep;
 
     @Autowired
-    public void setMarginBonusServiceImpl(UserSalaryRepImplRep userSalaryRepImplRep){
+    public MarginBonusServiceImpl(UserSalaryRepImplRep userSalaryRepImplRep) {
         this.userSalaryRepImplRep = userSalaryRepImplRep;
     }
 
@@ -42,6 +43,7 @@ public class MarginBonusServiceImpl implements iMarginBonusService {
     }
 
     @Override
+    @Transactional
     public void saveFailedProbationAct(Integer actId, Double totalNoNds, String candidate,
                                        List<ActByUserCheck> participants) {
         userSalaryRepImplRep.saveFailedProbationAct(actId, totalNoNds, candidate, participants);


### PR DESCRIPTION
## Summary
- switch MarginBonusServiceImpl to constructor-based injection for the salary repository
- annotate saveFailedProbationAct with @Transactional and remove unused wiring

## Testing
- mvn -q -DskipTests compile *(fails: parent POM download blocked by repository 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5d667dfc832184382b308ef609f1)