### PR TITLE
Ensure client act totals use unique act ids

### DIFF
--- a/src/main/java/ru/alta/thirdproj/controllers/ActPutController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/ActPutController.java
@@ -57,12 +57,9 @@ public class ActPutController {
                 .mapToDouble(Act::getBonus)
                 .sum();
 
-//        double allActMoneyPeriod = actList.stream()
-//                .filter(e -> !e.isPaid())
-//                .mapToDouble(Act::getBonus)
-//                .sum();
-
+        Set<Integer> seenActIds = new HashSet<>();
         double allActForClientMoneyPeriod = actList.stream()
+                .filter(act -> seenActIds.add(act.getId()))
                 .mapToDouble(Act::getBonus)
                 .sum();
 

--- a/src/main/java/ru/alta/thirdproj/controllers/ActPutController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/ActPutController.java
@@ -2,6 +2,8 @@ package ru.alta.thirdproj.controllers;
 
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
@@ -27,7 +29,7 @@ import java.util.stream.Collectors;
 @Tag(name="ActPutController", description="Управление актами")
 public class ActPutController {
 
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActPutController.class);
+    private static final Logger log = LoggerFactory.getLogger(ActPutController.class);
 
     private ActPutServiceImpl actBonusPercentService;
     private ExpectedMoneyByFinalistService moneyByFinalistService;
@@ -74,7 +76,15 @@ public class ActPutController {
                 .collect(Collectors.toList());
 
         if (!duplicateActIds.isEmpty()) {
-            log.info("Найдены дубликаты act_id за период {} - {}: {}", date1, date2, duplicateActIds);
+            log.warn("Найдены дубликаты act_id за период {} - {}: {}", date1, date2, duplicateActIds);
+            Map<Integer, List<String>> duplicateDetails = actList.stream()
+                    .filter(act -> duplicateActIds.contains(act.getId()))
+                    .collect(Collectors.groupingBy(Act::getId,
+                            Collectors.mapping(act -> String.format("paymentDate=%s, dateAct=%s, bonus=%.2f, paid=%s",
+                                    act.getPaymentDate(), act.getDateAct(), act.getBonus(), act.getPaid()),
+                                    Collectors.toList())));
+            duplicateDetails.forEach((actId, details) ->
+                    log.warn("act_id {} встречается {} раз(а): {}", actId, details.size(), String.join("; ", details)));
         } else {
             log.info("Дубликаты act_id за период {} - {} не обнаружены", date1, date2);
         }

--- a/src/main/java/ru/alta/thirdproj/controllers/ActPutController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/ActPutController.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 @Tag(name="ActPutController", description="Управление актами")
 public class ActPutController {
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActPutController.class);
+
     private ActPutServiceImpl actBonusPercentService;
     private ExpectedMoneyByFinalistService moneyByFinalistService;
 
@@ -62,6 +64,23 @@ public class ActPutController {
                 .filter(act -> seenActIds.add(act.getId()))
                 .mapToDouble(Act::getBonus)
                 .sum();
+
+        Map<Integer, Long> actIdOccurrences = actList.stream()
+                .collect(Collectors.groupingBy(Act::getId, Collectors.counting()));
+        List<Integer> duplicateActIds = actIdOccurrences.entrySet().stream()
+                .filter(entry -> entry.getValue() > 1)
+                .map(Map.Entry::getKey)
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (!duplicateActIds.isEmpty()) {
+            log.info("Найдены дубликаты act_id за период {} - {}: {}", date1, date2, duplicateActIds);
+        } else {
+            log.info("Дубликаты act_id за период {} - {} не обнаружены", date1, date2);
+        }
+        log.info("Акты за период {} - {}: всего {}, уникальных act_id {}, сумма по уникальным bonus={}, сумма по всем bonus={}",
+                date1, date2, actList.size(), actIdOccurrences.size(),
+                allActForClientMoneyPeriod, actList.stream().mapToDouble(Act::getBonus).sum());
 
         double allActMoneyPeriodPaid = actList.stream()
                 .filter(e -> e.getPaymentDate() != null)

--- a/src/main/java/ru/alta/thirdproj/controllers/ActsController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/ActsController.java
@@ -58,6 +58,8 @@ public class ActsController {
         Locale ru = new Locale("ru", "RU");
         NumberFormat currencyInstance = NumberFormat.getCurrencyInstance(ru);
 
+        logger.info("Формирование отчета по актам за период {} - {}", date1, date2);
+
         List<Act> actList = actBonusPercentService.getAllPutAct(date1, date2)
                 .stream()
                 .sorted(Comparator.comparingInt(Act::getId))
@@ -74,11 +76,36 @@ public class ActsController {
                 .mapToDouble(Act::getBonus)
                 .sum();
 
-
+        Set<Integer> seenActIds = new HashSet<>();
         double allActForClientMoneyPeriod = actList.stream()
                 .filter(act -> !act.getDateAct().isBefore(date1) && !act.getDateAct().isAfter(date2))
+                .filter(act -> seenActIds.add(act.getId()))
                 .mapToDouble(Act::getBonus)
                 .sum();
+
+        Map<Integer, Long> actIdOccurrences = actList.stream()
+                .collect(Collectors.groupingBy(Act::getId, Collectors.counting()));
+        List<Integer> duplicateActIds = actIdOccurrences.entrySet().stream()
+                .filter(entry -> entry.getValue() > 1)
+                .map(Map.Entry::getKey)
+                .sorted()
+                .collect(Collectors.toList());
+        if (!duplicateActIds.isEmpty()) {
+            logger.warn("Найдены дубликаты act_id за период {} - {}: {}", date1, date2, duplicateActIds);
+            Map<Integer, List<String>> duplicateDetails = actList.stream()
+                    .filter(act -> duplicateActIds.contains(act.getId()))
+                    .collect(Collectors.groupingBy(Act::getId,
+                            Collectors.mapping(act -> String.format("paymentDate=%s, dateAct=%s, bonus=%.2f, paid=%s",
+                                    act.getPaymentDate(), act.getDateAct(), act.getBonus(), act.getPaid()),
+                                    Collectors.toList())));
+            duplicateDetails.forEach((actId, details) ->
+                    logger.warn("act_id {} встречается {} раз(а): {}", actId, details.size(), String.join("; ", details)));
+        } else {
+            logger.info("Дубликаты act_id за период {} - {} не обнаружены", date1, date2);
+        }
+        logger.info("Акты за период {} - {}: всего записей {}, уникальных act_id {}, сумма по уникальным bonus={}, сумма по всем bonus={}",
+                date1, date2, actList.size(), actIdOccurrences.size(),
+                allActForClientMoneyPeriod, actList.stream().mapToDouble(Act::getBonus).sum());
 
         double allActMoneyPeriodPaid = actList.stream()
                 .filter(e -> e.getPaymentDate() != null)


### PR DESCRIPTION
## Summary
- ensure act totals for clients sum bonus amounts only once per act id in ActPutController

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e5576f1588321b206d405724a30f7)