### PR TITLE
Add paymentBuhId to bonus payment flow

### DIFF
--- a/src/main/java/ru/alta/thirdproj/controllers/BonusPaymentController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/BonusPaymentController.java
@@ -175,6 +175,7 @@ public class BonusPaymentController {
         System.out.println("paid: " + request.isPaid());
         System.out.println("datePayment: " + request.getDatePayment());
         System.out.println("paymentRealDate: " + request.getPaymentRealDate());
+        System.out.println("paymentBuhId: " + request.getPaymentBuhId());
         System.out.println("========================================");
     }
 
@@ -197,6 +198,10 @@ public class BonusPaymentController {
             errors.add("candidate обязателен");
         }
 
+        if (request.getPaymentBuhId() == null) {
+            errors.add("paymentBuhId обязателен");
+        }
+
         return errors;
     }
 
@@ -212,6 +217,7 @@ public class BonusPaymentController {
     private void processPayment(PaymentUpdateRequest request, User user) throws Exception {
         LocalDate paymentDate = request.getPaymentRealDate() != null ?
                 request.getPaymentRealDate() : LocalDate.now();
+        int paymentBuhId = request.getPaymentBuhId() != null ? request.getPaymentBuhId() : 0;
 
         if (request.isPaid()) {
             // Оплата бонуса
@@ -239,7 +245,8 @@ public class BonusPaymentController {
                     request.getCandidate(),
                     0,
                     month,
-                    type
+                    type,
+                    paymentBuhId
             );
         } else {
             // Отмена оплаты
@@ -250,7 +257,8 @@ public class BonusPaymentController {
                     request.getBonus(),
                     request.getActId(),
                     request.getCandidate(),
-                    request.getBonus()
+                    request.getBonus(),
+                    paymentBuhId
             );
         }
     }
@@ -261,7 +269,8 @@ public class BonusPaymentController {
                     user.getUserId(),
                     request.getActId(),
                     request.getCandidate(),
-                    request.getBonus()
+                    request.getBonus(),
+                    request.getPaymentBuhId() != null ? request.getPaymentBuhId() : 0
             );
             return paymentRecord.orElse(null);
         } catch (Exception e) {

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
@@ -21,6 +21,7 @@ public class PaymentSuccess {
     private int projectId;
     private int monthKPI;
     private int type;
+    private int paymentBuhId;
     public String getPaymentDateOnly() {
         if (paymentDate == null) return null;
         return new SimpleDateFormat("dd-MM-yyyy").format(paymentDate);
@@ -39,6 +40,7 @@ public class PaymentSuccess {
         COLUMN_MAPPINGS.put("payment_real_summ", "paymentRealSum");
         COLUMN_MAPPINGS.put("monthKPI", "month_kpi");
         COLUMN_MAPPINGS.put("type", "payment_type");
+        COLUMN_MAPPINGS.put("payment_buh_id", "paymentBuhId");
 
     }
 

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
@@ -14,6 +14,7 @@ public class PaymentUpdateRequest {
     private Double bonus;
     private boolean paid;
     private String datePayment;
+    private Integer paymentBuhId;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate paymentRealDate; // Используем LocalDate для SQL Server
@@ -26,8 +27,8 @@ public class PaymentUpdateRequest {
     @Override
     public String toString() {
         return String.format(
-                "PaymentUpdateRequest[actId=%d, employerId=%d, candidate=%s, bonus=%.2f, paid=%b, datePayment=%s, paymentRealDate=%s]",
-                actId, employerId, candidate, bonus, paid, datePayment, paymentRealDate
+                "PaymentUpdateRequest[actId=%d, employerId=%d, candidate=%s, bonus=%.2f, paid=%b, datePayment=%s, paymentRealDate=%s, paymentBuhId=%d]",
+                actId, employerId, candidate, bonus, paid, datePayment, paymentRealDate, paymentBuhId
         );
     }
 }

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -16,7 +16,8 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
 
     private static final String SELECT_BONUS_PAYMENT_QUERY
-            = "insert INTO paymentSuccess values (:user_id ,\n" +
+            = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, " +
+            "payment_real_summ, month_kpi, payment_type, payment_buh_id) values (:user_id ,\n" +
             ":employer_id ,\n" +
             ":payment_date ,\n" +
             ":payment_summ, " +
@@ -25,22 +26,25 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":project_id,\n" +
             ":payment_real_summ," +
             ":month_kpi," +
-            ":payment_type)";
+            ":payment_type," +
+            ":payment_buh_id)";
     private static final String SELECT_ID_BONUS_PAYMENT
-            = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ " +
-            "FROM paymentSuccess ps WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate and ps.payment_summ = :payment_summ";
+            = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, payment_buh_id " +
+            "FROM paymentSuccess ps WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate " +
+            "and ps.payment_summ = :payment_summ and ps.payment_buh_id = :payment_buh_id";
 
 
     private static final String UPDATE_BONUS_PAYMENT =
     "UPDATE [dbo].[paymentSuccess]  SET  employer_id = :employer_id,  payment_date = :payment_date ,payment_real_summ = :payment_real_summ" +
-            "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate";
+            "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate and ps.payment_buh_id = :payment_buh_id";
 
     private static final String DELETE_BONUS_PAYMENT =
-            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ";
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate " +
+            "and payment_summ = :payment_summ and payment_buh_id = :payment_buh_id";
 
 
     private static final String DELETE_BONUS_PAYMENT_KPI = "DELETE paymentSuccess WHERE employer_id = :user_id and candidate = :candidate \n" +
-            "\t\t\tand payment_summ = :payment_summ";
+            "\t\t\tand payment_summ = :payment_summ and payment_buh_id = :payment_buh_id";
 
 
     private static final String DELETE_BONUS_PAYMENT_ALL =
@@ -67,6 +71,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                     .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
                     .addParameter("month_kpi", paymentSuccess.getMonthKPI())
                     .addParameter("payment_type", paymentSuccess.getType())
+                    .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId())
                     .executeUpdate();
             connection.commit();
 
@@ -74,7 +79,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     }
 
     @Override
-    public PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ) {
+    public PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ, int paymentBuhId) {
         try (Connection connection = sql2o.open()) {
             return connection.createQuery(SELECT_ID_BONUS_PAYMENT)
                     .throwOnMappingFailure(false)
@@ -82,6 +87,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                     .addParameter("act_id", actId)
                     .addParameter("candidate", candidate)
                     .addParameter("payment_summ", summ)
+                    .addParameter("payment_buh_id", paymentBuhId)
                     .setColumnMappings(PaymentSuccess.COLUMN_MAPPINGS)
                     .executeAndFetchFirst(PaymentSuccess.class);
         }
@@ -91,13 +97,14 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
     @Transactional
     @Override
-    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate) {
+    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, int paymentBuhId) {
         try (Connection connection = sql2o.open()) {
             connection.createQuery(DELETE_BONUS_PAYMENT, false)
                     .addParameter("user_id", employerId)
                     .addParameter("payment_summ", paymentSum)
                     .addParameter("act_id", actId)
                     .addParameter("candidate", candidate)
+                    .addParameter("payment_buh_id", paymentBuhId)
                     .executeUpdate();
             connection.commit();
 
@@ -106,12 +113,13 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
     @Transactional
     @Override
-    public void deletePaymentKPI(int employerId, Double paymentSum, String candidate) {
+    public void deletePaymentKPI(int employerId, Double paymentSum, String candidate, int paymentBuhId) {
         try (Connection connection = sql2o.open()) {
             connection.createQuery(DELETE_BONUS_PAYMENT_KPI, false)
                     .addParameter("user_id", employerId)
                     .addParameter("payment_summ", paymentSum)
                     .addParameter("candidate", candidate)
+                    .addParameter("payment_buh_id", paymentBuhId)
                     .executeUpdate();
             connection.commit();
 
@@ -131,7 +139,8 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
     @Transactional
     @Override
-    public void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate)
+    public void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId,
+                              String candidate, int paymentBuhId)
     {
         try (Connection connection = sql2o.open()) {
             connection.createQuery(UPDATE_BONUS_PAYMENT, false)
@@ -141,6 +150,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                     .addParameter("payment_real_summ", paymentRealSum)
                     .addParameter("act_id", actId)
                     .addParameter("candidate", candidate)
+                    .addParameter("payment_buh_id", paymentBuhId)
                     .executeUpdate();
             connection.commit();
 

--- a/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
@@ -8,10 +8,10 @@ import java.util.List;
 public interface IBonusPaymentSuccess {
 
     void save(PaymentSuccess paymentSuccess);
-    PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ);
-    void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate);
-    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate);
-    void deletePaymentKPI(int employerId, Double paymentSum, String candidate);
+    PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ, int paymentBuhId);
+    void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate, int paymentBuhId);
+    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate, int paymentBuhId);
+    void deletePaymentKPI(int employerId, Double paymentSum, String candidate, int paymentBuhId);
     void deletePaymentAll();
 
 }

--- a/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
@@ -24,7 +24,7 @@ public class BonusPaymentSuccessServiceImpl {
 
 
     public boolean addPayment(int userId, int employerId, Double paymentSum, int actId, String candidate,
-                              int projectId, int monthKPI, int type){
+                              int projectId, int monthKPI, int type, int paymentBuhId){
 
         PaymentSuccess paymentSuccess = new PaymentSuccess();
 //        if (!findByActId(userId, actId, candidate, paymentSum).isEmpty()) {
@@ -41,13 +41,15 @@ public class BonusPaymentSuccessServiceImpl {
         paymentSuccess.setProjectId(projectId);
         paymentSuccess.setMonthKPI(monthKPI);
         paymentSuccess.setType(type);
+        paymentSuccess.setPaymentBuhId(paymentBuhId);
         bonusPaymentSuccess.save(paymentSuccess);
 
         return true;
     }
 
-    public Optional<PaymentSuccess> findByActId(int userId, int actId, String candidate, Double summ){
-        return Optional.ofNullable(bonusPaymentSuccess.findOneByAct(userId, actId, candidate, summ));
+    public Optional<PaymentSuccess> findByActId(int userId, int actId, String candidate, Double summ,
+                                                int paymentBuhId){
+        return Optional.ofNullable(bonusPaymentSuccess.findOneByAct(userId, actId, candidate, summ, paymentBuhId));
 
     }
 
@@ -92,17 +94,19 @@ public class BonusPaymentSuccessServiceImpl {
     }
 
 
-    public void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate, Double summ){
+    public void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId,
+                              String candidate, Double summ, int paymentBuhId){
 
-        if (findByActId(userId, actId, candidate, summ) != null) {
-            bonusPaymentSuccess.updatePayment(userId, employerId, paymentDate, paymentRealSum, actId, candidate);
+        if (findByActId(userId, actId, candidate, summ, paymentBuhId) != null) {
+            bonusPaymentSuccess.updatePayment(userId, employerId, paymentDate, paymentRealSum, actId, candidate, paymentBuhId);
         }
     }
 
-    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ){
+    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId,
+                              String candidate, Double summ, int paymentBuhId){
 
-        if (findByActId(userId, actId, candidate, summ) != null) {
-            bonusPaymentSuccess.deletePayment(employerId, paymentRealSum, actId, candidate);
+        if (findByActId(userId, actId, candidate, summ, paymentBuhId) != null) {
+            bonusPaymentSuccess.deletePayment(employerId, paymentRealSum, actId, candidate, paymentBuhId);
         }
     }
 
@@ -158,5 +162,4 @@ public class BonusPaymentSuccessServiceImpl {
 
 
 }
-
 


### PR DESCRIPTION
### Motivation
- Introduce a bookkeeping identifier `paymentBuhId` for bonus payments so records can be disambiguated and tracked. 
- Ensure all DB queries and service/controller flows include this identifier when creating, finding, updating and deleting payment success records.

### Description
- Added `paymentBuhId` field and column mapping to `PaymentSuccess` and added `paymentBuhId` to `PaymentUpdateRequest` with `toString()` updated.
- Updated repository API in `IBonusPaymentSuccess` and implemented changes in `BonusPaymentSuccessRepositoryImpl` to include `payment_buh_id` in `INSERT`, `SELECT`, `UPDATE` and `DELETE` statements and added it to `WHERE` clauses for `UPDATE` and `DELETE`.
- Threaded `paymentBuhId` through the service in `BonusPaymentSuccessServiceImpl` (save/find/update/delete) and set it on created `PaymentSuccess` objects.
- Updated `BonusPaymentController` to validate and log `paymentBuhId` and to pass it into `paymentSuccessService.addPayment` and `paymentSuccessService.deletePayment` and find operations.

### Testing
- No automated tests were run as part of this change.
- Changes were committed locally (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f6e87e5083219132d63eea7a32c4)