### PR TITLE
Добавить передачу и сохранение paymentBuhId при updatePaymentStatus

### DIFF
--- a/src/main/java/ru/alta/thirdproj/controllers/BonusPaymentController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/BonusPaymentController.java
@@ -251,7 +251,8 @@ public class BonusPaymentController {
                     request.getBonus(),
                     request.getActId(),
                     request.getCandidate(),
-                    request.getBonus()
+                    request.getBonus(),
+                    request.getPaymentBuhId()
             );
         }
     }

--- a/src/main/java/ru/alta/thirdproj/controllers/BonusPaymentController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/BonusPaymentController.java
@@ -239,7 +239,8 @@ public class BonusPaymentController {
                     request.getCandidate(),
                     0,
                     month,
-                    type
+                    type,
+                    request.getPaymentBuhId()
             );
         } else {
             // Отмена оплаты

--- a/src/main/java/ru/alta/thirdproj/entites/Act.java
+++ b/src/main/java/ru/alta/thirdproj/entites/Act.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.UUID;
 
 @Data
 public class Act {
@@ -27,5 +28,5 @@ public class Act {
     private String dateClientPay;
     private String bonusRUB;
     private String organization;
-    private String paymentBuhId;
+    private UUID paymentBuhId;
 }

--- a/src/main/java/ru/alta/thirdproj/entites/Act.java
+++ b/src/main/java/ru/alta/thirdproj/entites/Act.java
@@ -27,5 +27,5 @@ public class Act {
     private String dateClientPay;
     private String bonusRUB;
     private String organization;
-    private Integer paymentBuhId;
+    private String paymentBuhId;
 }

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.UUID;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +22,7 @@ public class PaymentSuccess {
     private int projectId;
     private int monthKPI;
     private int type;
-    private String paymentBuhId;
+    private UUID paymentBuhId;
     public String getPaymentDateOnly() {
         if (paymentDate == null) return null;
         return new SimpleDateFormat("dd-MM-yyyy").format(paymentDate);

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
@@ -21,6 +21,7 @@ public class PaymentSuccess {
     private int projectId;
     private int monthKPI;
     private int type;
+    private Integer paymentBuhId;
     public String getPaymentDateOnly() {
         if (paymentDate == null) return null;
         return new SimpleDateFormat("dd-MM-yyyy").format(paymentDate);
@@ -39,6 +40,7 @@ public class PaymentSuccess {
         COLUMN_MAPPINGS.put("payment_real_summ", "paymentRealSum");
         COLUMN_MAPPINGS.put("monthKPI", "month_kpi");
         COLUMN_MAPPINGS.put("type", "payment_type");
+        COLUMN_MAPPINGS.put("payment_buh_id", "paymentBuhId");
 
     }
 

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
@@ -21,7 +21,7 @@ public class PaymentSuccess {
     private int projectId;
     private int monthKPI;
     private int type;
-    private Integer paymentBuhId;
+    private String paymentBuhId;
     public String getPaymentDateOnly() {
         if (paymentDate == null) return null;
         return new SimpleDateFormat("dd-MM-yyyy").format(paymentDate);

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentSuccess.java
@@ -42,6 +42,7 @@ public class PaymentSuccess {
         COLUMN_MAPPINGS.put("monthKPI", "month_kpi");
         COLUMN_MAPPINGS.put("type", "payment_type");
         COLUMN_MAPPINGS.put("payment_buh_id", "paymentBuhId");
+        COLUMN_MAPPINGS.put("pay_guid", "paymentBuhId");
 
     }
 

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Data
 public class PaymentUpdateRequest {
@@ -14,7 +15,7 @@ public class PaymentUpdateRequest {
     private Double bonus;
     private boolean paid;
     private String datePayment;
-    private String paymentBuhId;
+    private UUID paymentBuhId;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate paymentRealDate; // Используем LocalDate для SQL Server

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
@@ -14,7 +14,7 @@ public class PaymentUpdateRequest {
     private Double bonus;
     private boolean paid;
     private String datePayment;
-    private Integer paymentBuhId;
+    private String paymentBuhId;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate paymentRealDate; // Используем LocalDate для SQL Server

--- a/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PaymentUpdateRequest.java
@@ -14,6 +14,7 @@ public class PaymentUpdateRequest {
     private Double bonus;
     private boolean paid;
     private String datePayment;
+    private Integer paymentBuhId;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate paymentRealDate; // Используем LocalDate для SQL Server
@@ -26,8 +27,8 @@ public class PaymentUpdateRequest {
     @Override
     public String toString() {
         return String.format(
-                "PaymentUpdateRequest[actId=%d, employerId=%d, candidate=%s, bonus=%.2f, paid=%b, datePayment=%s, paymentRealDate=%s]",
-                actId, employerId, candidate, bonus, paid, datePayment, paymentRealDate
+                "PaymentUpdateRequest[actId=%d, employerId=%d, candidate=%s, bonus=%.2f, paid=%b, datePayment=%s, paymentRealDate=%s, paymentBuhId=%s]",
+                actId, employerId, candidate, bonus, paid, datePayment, paymentRealDate, paymentBuhId
         );
     }
 }

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentRepositoryImpl.java
@@ -137,18 +137,8 @@ public class BonusPaymentRepositoryImpl {
         }
 
         Object payBuId = row.get("payment_buh_id");
-        if (percentValue != null) {
-            Integer payBuIdInt = null;
-            if (payBuId instanceof Integer) {
-                payBuIdInt = (Integer) payBuId;
-            } else if (percentValue instanceof BigDecimal) {
-                payBuIdInt = ((BigDecimal) payBuId).intValue();
-            } else if (payBuId instanceof Long) {
-                payBuIdInt = ((Long) payBuId).intValue();
-            }
-            if (payBuIdInt != null) {
-                act.setPaymentBuhId(payBuIdInt);
-            }
+        if (payBuId != null) {
+            act.setPaymentBuhId(payBuId.toString());
         }
 
 

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentRepositoryImpl.java
@@ -137,10 +137,12 @@ public class BonusPaymentRepositoryImpl {
             }
         }
 
+        Object payGuid = row.get("pay_guid");
         Object payBuId = row.get("payment_buh_id");
-        if (payBuId != null) {
+        Object paymentGuidSource = payGuid != null ? payGuid : payBuId;
+        if (paymentGuidSource != null) {
             try {
-                act.setPaymentBuhId(UUID.fromString(payBuId.toString()));
+                act.setPaymentBuhId(UUID.fromString(paymentGuidSource.toString()));
             } catch (IllegalArgumentException ignored) {
                 act.setPaymentBuhId(null);
             }

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentRepositoryImpl.java
@@ -14,6 +14,7 @@ import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -138,7 +139,11 @@ public class BonusPaymentRepositoryImpl {
 
         Object payBuId = row.get("payment_buh_id");
         if (payBuId != null) {
-            act.setPaymentBuhId(payBuId.toString());
+            try {
+                act.setPaymentBuhId(UUID.fromString(payBuId.toString()));
+            } catch (IllegalArgumentException ignored) {
+                act.setPaymentBuhId(null);
+            }
         }
 
 

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -93,7 +93,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
     @Transactional
     @Override
-    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, Integer paymentBuhId) {
+    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, String paymentBuhId) {
         try (Connection connection = sql2o.open()) {
             connection.createQuery(DELETE_BONUS_PAYMENT, false)
                     .addParameter("user_id", employerId)

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -74,7 +74,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     @Transactional
     public void save(PaymentSuccess paymentSuccess)
     {
-        try (Connection connection = sql2o.open()) {
+        try (Connection connection = sql2o.beginTransaction()) {
             try {
                 connection.createQuery(SELECT_BONUS_PAYMENT_QUERY, false)
                         .addParameter("user_id", paymentSuccess.getUserId())
@@ -131,7 +131,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     @Transactional
     @Override
     public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, UUID paymentBuhId) {
-        try (Connection connection = sql2o.open()) {
+        try (Connection connection = sql2o.beginTransaction()) {
             try {
                 connection.createQuery(DELETE_BONUS_PAYMENT, false)
                         .addParameter("user_id", employerId)
@@ -160,7 +160,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     @Transactional
     @Override
     public void deletePaymentKPI(int employerId, Double paymentSum, String candidate) {
-        try (Connection connection = sql2o.open()) {
+        try (Connection connection = sql2o.beginTransaction()) {
             connection.createQuery(DELETE_BONUS_PAYMENT_KPI, false)
                     .addParameter("user_id", employerId)
                     .addParameter("payment_summ", paymentSum)
@@ -174,7 +174,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     @Transactional
     @Override
     public void deletePaymentAll() {
-        try (Connection connection = sql2o.open()) {
+        try (Connection connection = sql2o.beginTransaction()) {
             connection.createQuery(DELETE_BONUS_PAYMENT_ALL, false)
                     .executeUpdate();
             connection.commit();
@@ -186,7 +186,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     @Override
     public void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate)
     {
-        try (Connection connection = sql2o.open()) {
+        try (Connection connection = sql2o.beginTransaction()) {
             connection.createQuery(UPDATE_BONUS_PAYMENT, false)
                     .addParameter("user_id", userId)
                     .addParameter("employer_id", employerId)

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -28,7 +28,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":payment_real_summ," +
             ":month_kpi," +
             ":payment_type," +
-            ":payment_buh_id)";
+            "CAST(:payment_buh_id as uniqueidentifier))";
 
     private static final String SELECT_BONUS_PAYMENT_QUERY_LEGACY
             = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, month_kpi, payment_type) values (:user_id ,\n" +
@@ -51,7 +51,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate";
 
     private static final String DELETE_BONUS_PAYMENT =
-            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((CONVERT(nvarchar(64), payment_buh_id) = CONVERT(nvarchar(64), :payment_buh_id)) or (:payment_buh_id is null and payment_buh_id is null))";
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((payment_buh_id = CAST(:payment_buh_id as uniqueidentifier)) or (:payment_buh_id is null and payment_buh_id is null))";
 
 
 
@@ -87,21 +87,25 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                         .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
                         .addParameter("month_kpi", paymentSuccess.getMonthKPI())
                         .addParameter("payment_type", paymentSuccess.getType())
-                        .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId())
+                        .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId() != null ? paymentSuccess.getPaymentBuhId().toString() : null)
                         .executeUpdate();
             } catch (Sql2oException e) {
-                connection.createQuery(SELECT_BONUS_PAYMENT_QUERY_LEGACY, false)
-                        .addParameter("user_id", paymentSuccess.getUserId())
-                        .addParameter("employer_id", paymentSuccess.getEmployerId() )
-                        .addParameter("payment_date", paymentSuccess.getPaymentDate())
-                        .addParameter("payment_summ", paymentSuccess.getPaymentSum())
-                        .addParameter("act_id", paymentSuccess.getActId())
-                        .addParameter("candidate", paymentSuccess.getCandidate())
-                        .addParameter("project_id", paymentSuccess.getProjectId())
-                        .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
-                        .addParameter("month_kpi", paymentSuccess.getMonthKPI())
-                        .addParameter("payment_type", paymentSuccess.getType())
-                        .executeUpdate();
+                if (isMissingPaymentBuhIdColumnError(e)) {
+                    connection.createQuery(SELECT_BONUS_PAYMENT_QUERY_LEGACY, false)
+                            .addParameter("user_id", paymentSuccess.getUserId())
+                            .addParameter("employer_id", paymentSuccess.getEmployerId() )
+                            .addParameter("payment_date", paymentSuccess.getPaymentDate())
+                            .addParameter("payment_summ", paymentSuccess.getPaymentSum())
+                            .addParameter("act_id", paymentSuccess.getActId())
+                            .addParameter("candidate", paymentSuccess.getCandidate())
+                            .addParameter("project_id", paymentSuccess.getProjectId())
+                            .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
+                            .addParameter("month_kpi", paymentSuccess.getMonthKPI())
+                            .addParameter("payment_type", paymentSuccess.getType())
+                            .executeUpdate();
+                } else {
+                    throw e;
+                }
             }
             connection.commit();
 
@@ -134,15 +138,19 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                         .addParameter("payment_summ", paymentSum)
                         .addParameter("act_id", actId)
                         .addParameter("candidate", candidate)
-                        .addParameter("payment_buh_id", paymentBuhId)
+                        .addParameter("payment_buh_id", paymentBuhId != null ? paymentBuhId.toString() : null)
                         .executeUpdate();
             } catch (Sql2oException e) {
-                connection.createQuery(DELETE_BONUS_PAYMENT_LEGACY, false)
-                        .addParameter("user_id", employerId)
-                        .addParameter("payment_summ", paymentSum)
-                        .addParameter("act_id", actId)
-                        .addParameter("candidate", candidate)
-                        .executeUpdate();
+                if (isMissingPaymentBuhIdColumnError(e)) {
+                    connection.createQuery(DELETE_BONUS_PAYMENT_LEGACY, false)
+                            .addParameter("user_id", employerId)
+                            .addParameter("payment_summ", paymentSum)
+                            .addParameter("act_id", actId)
+                            .addParameter("candidate", candidate)
+                            .executeUpdate();
+                } else {
+                    throw e;
+                }
             }
             connection.commit();
 
@@ -191,4 +199,14 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
         }
     }
+    private boolean isMissingPaymentBuhIdColumnError(Sql2oException e) {
+        if (e.getMessage() == null) {
+            return false;
+        }
+
+        String msg = e.getMessage().toLowerCase();
+        return msg.contains("payment_buh_id") &&
+                (msg.contains("invalid column") || msg.contains("column") && msg.contains("not found"));
+    }
+
 }

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.sql2o.Sql2o;
 import ru.alta.thirdproj.entites.PaymentSuccess;
 
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
@@ -26,7 +27,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":payment_real_summ," +
             ":month_kpi," +
             ":payment_type," +
-            ":payment_buh_id)";
+            "CAST(:payment_buh_id as uniqueidentifier))";
     private static final String SELECT_ID_BONUS_PAYMENT
             = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, payment_buh_id " +
             "FROM paymentSuccess ps WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate and ps.payment_summ = :payment_summ";
@@ -37,7 +38,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate";
 
     private static final String DELETE_BONUS_PAYMENT =
-            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((payment_buh_id = :payment_buh_id) or (:payment_buh_id is null and payment_buh_id is null))";
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((payment_buh_id = CAST(:payment_buh_id as uniqueidentifier)) or (:payment_buh_id is null and payment_buh_id is null))";
 
 
     private static final String DELETE_BONUS_PAYMENT_KPI = "DELETE paymentSuccess WHERE employer_id = :user_id and candidate = :candidate \n" +
@@ -93,7 +94,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
     @Transactional
     @Override
-    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, String paymentBuhId) {
+    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, UUID paymentBuhId) {
         try (Connection connection = sql2o.open()) {
             connection.createQuery(DELETE_BONUS_PAYMENT, false)
                     .addParameter("user_id", employerId)

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -16,7 +16,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
 
     private static final String SELECT_BONUS_PAYMENT_QUERY
-            = "insert INTO paymentSuccess values (:user_id ,\n" +
+            = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, month_kpi, payment_type, payment_buh_id) values (:user_id ,\n" +
             ":employer_id ,\n" +
             ":payment_date ,\n" +
             ":payment_summ, " +
@@ -25,9 +25,10 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":project_id,\n" +
             ":payment_real_summ," +
             ":month_kpi," +
-            ":payment_type)";
+            ":payment_type," +
+            ":payment_buh_id)";
     private static final String SELECT_ID_BONUS_PAYMENT
-            = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ " +
+            = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, payment_buh_id " +
             "FROM paymentSuccess ps WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate and ps.payment_summ = :payment_summ";
 
 
@@ -67,6 +68,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                     .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
                     .addParameter("month_kpi", paymentSuccess.getMonthKPI())
                     .addParameter("payment_type", paymentSuccess.getType())
+                    .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId())
                     .executeUpdate();
             connection.commit();
 

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -18,7 +18,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
 
     private static final String SELECT_BONUS_PAYMENT_QUERY
-            = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, month_kpi, payment_type, payment_buh_id) values (:user_id ,\n" +
+            = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, month_kpi, payment_type, pay_guid) values (:user_id ,\n" +
             ":employer_id ,\n" +
             ":payment_date ,\n" +
             ":payment_summ, " +
@@ -28,7 +28,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":payment_real_summ," +
             ":month_kpi," +
             ":payment_type," +
-            "CAST(:payment_buh_id as uniqueidentifier))";
+            "CAST(:pay_guid as uniqueidentifier))";
 
     private static final String SELECT_BONUS_PAYMENT_QUERY_LEGACY
             = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, month_kpi, payment_type) values (:user_id ,\n" +
@@ -42,7 +42,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":month_kpi," +
             ":payment_type)";
     private static final String SELECT_ID_BONUS_PAYMENT
-            = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, payment_buh_id " +
+            = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, pay_guid as payment_buh_id " +
             "FROM paymentSuccess ps WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate and ps.payment_summ = :payment_summ";
 
 
@@ -51,7 +51,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate";
 
     private static final String DELETE_BONUS_PAYMENT =
-            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((payment_buh_id = CAST(:payment_buh_id as uniqueidentifier)) or (:payment_buh_id is null and payment_buh_id is null))";
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((pay_guid = CAST(:pay_guid as uniqueidentifier)) or (:pay_guid is null and pay_guid is null))";
 
 
 
@@ -87,7 +87,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                         .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
                         .addParameter("month_kpi", paymentSuccess.getMonthKPI())
                         .addParameter("payment_type", paymentSuccess.getType())
-                        .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId() != null ? paymentSuccess.getPaymentBuhId().toString() : null)
+                        .addParameter("pay_guid", paymentSuccess.getPaymentBuhId() != null ? paymentSuccess.getPaymentBuhId().toString() : null)
                         .executeUpdate();
             } catch (Sql2oException e) {
                 if (isMissingPaymentBuhIdColumnError(e)) {
@@ -138,7 +138,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
                         .addParameter("payment_summ", paymentSum)
                         .addParameter("act_id", actId)
                         .addParameter("candidate", candidate)
-                        .addParameter("payment_buh_id", paymentBuhId != null ? paymentBuhId.toString() : null)
+                        .addParameter("pay_guid", paymentBuhId != null ? paymentBuhId.toString() : null)
                         .executeUpdate();
             } catch (Sql2oException e) {
                 if (isMissingPaymentBuhIdColumnError(e)) {
@@ -205,7 +205,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
         }
 
         String msg = e.getMessage().toLowerCase();
-        return msg.contains("payment_buh_id") &&
+        return (msg.contains("payment_buh_id") || msg.contains("pay_guid")) &&
                 (msg.contains("invalid column") || msg.contains("column") && msg.contains("not found"));
     }
 

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -37,7 +37,7 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate";
 
     private static final String DELETE_BONUS_PAYMENT =
-            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ";
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((payment_buh_id = :payment_buh_id) or (:payment_buh_id is null and payment_buh_id is null))";
 
 
     private static final String DELETE_BONUS_PAYMENT_KPI = "DELETE paymentSuccess WHERE employer_id = :user_id and candidate = :candidate \n" +
@@ -93,13 +93,14 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
 
     @Transactional
     @Override
-    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate) {
+    public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, Integer paymentBuhId) {
         try (Connection connection = sql2o.open()) {
             connection.createQuery(DELETE_BONUS_PAYMENT, false)
                     .addParameter("user_id", employerId)
                     .addParameter("payment_summ", paymentSum)
                     .addParameter("act_id", actId)
                     .addParameter("candidate", candidate)
+                    .addParameter("payment_buh_id", paymentBuhId)
                     .executeUpdate();
             connection.commit();
 

--- a/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/BonusPaymentSuccessRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.sql2o.Connection;
 import org.sql2o.Sql2o;
+import org.sql2o.Sql2oException;
 import ru.alta.thirdproj.entites.PaymentSuccess;
 
 import java.util.Date;
@@ -27,7 +28,19 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             ":payment_real_summ," +
             ":month_kpi," +
             ":payment_type," +
-            "CAST(:payment_buh_id as uniqueidentifier))";
+            ":payment_buh_id)";
+
+    private static final String SELECT_BONUS_PAYMENT_QUERY_LEGACY
+            = "insert INTO paymentSuccess (user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, month_kpi, payment_type) values (:user_id ,\n" +
+            ":employer_id ,\n" +
+            ":payment_date ,\n" +
+            ":payment_summ, " +
+            ":act_id ,\n" +
+            ":candidate ,\n" +
+            ":project_id,\n" +
+            ":payment_real_summ," +
+            ":month_kpi," +
+            ":payment_type)";
     private static final String SELECT_ID_BONUS_PAYMENT
             = "SELECT user_id, employer_id, payment_date, payment_summ, act_id, candidate, project_id, payment_real_summ, payment_buh_id " +
             "FROM paymentSuccess ps WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate and ps.payment_summ = :payment_summ";
@@ -38,8 +51,12 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
             "  WHERE ps.user_id = :user_id and ps.act_id = :act_id and ps.candidate = :candidate";
 
     private static final String DELETE_BONUS_PAYMENT =
-            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((payment_buh_id = CAST(:payment_buh_id as uniqueidentifier)) or (:payment_buh_id is null and payment_buh_id is null))";
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ and ((CONVERT(nvarchar(64), payment_buh_id) = CONVERT(nvarchar(64), :payment_buh_id)) or (:payment_buh_id is null and payment_buh_id is null))";
 
+
+
+    private static final String DELETE_BONUS_PAYMENT_LEGACY =
+            "DELETE paymentSuccess WHERE employer_id = :user_id and act_id = :act_id and candidate = :candidate and payment_summ = :payment_summ";
 
     private static final String DELETE_BONUS_PAYMENT_KPI = "DELETE paymentSuccess WHERE employer_id = :user_id and candidate = :candidate \n" +
             "\t\t\tand payment_summ = :payment_summ";
@@ -58,19 +75,34 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     public void save(PaymentSuccess paymentSuccess)
     {
         try (Connection connection = sql2o.open()) {
-             connection.createQuery(SELECT_BONUS_PAYMENT_QUERY, false)
-                    .addParameter("user_id", paymentSuccess.getUserId())
-                    .addParameter("employer_id", paymentSuccess.getEmployerId() )
-                    .addParameter("payment_date", paymentSuccess.getPaymentDate())
-                    .addParameter("payment_summ", paymentSuccess.getPaymentSum())
-                    .addParameter("act_id", paymentSuccess.getActId())
-                    .addParameter("candidate", paymentSuccess.getCandidate())
-                    .addParameter("project_id", paymentSuccess.getProjectId())
-                    .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
-                    .addParameter("month_kpi", paymentSuccess.getMonthKPI())
-                    .addParameter("payment_type", paymentSuccess.getType())
-                    .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId())
-                    .executeUpdate();
+            try {
+                connection.createQuery(SELECT_BONUS_PAYMENT_QUERY, false)
+                        .addParameter("user_id", paymentSuccess.getUserId())
+                        .addParameter("employer_id", paymentSuccess.getEmployerId() )
+                        .addParameter("payment_date", paymentSuccess.getPaymentDate())
+                        .addParameter("payment_summ", paymentSuccess.getPaymentSum())
+                        .addParameter("act_id", paymentSuccess.getActId())
+                        .addParameter("candidate", paymentSuccess.getCandidate())
+                        .addParameter("project_id", paymentSuccess.getProjectId())
+                        .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
+                        .addParameter("month_kpi", paymentSuccess.getMonthKPI())
+                        .addParameter("payment_type", paymentSuccess.getType())
+                        .addParameter("payment_buh_id", paymentSuccess.getPaymentBuhId())
+                        .executeUpdate();
+            } catch (Sql2oException e) {
+                connection.createQuery(SELECT_BONUS_PAYMENT_QUERY_LEGACY, false)
+                        .addParameter("user_id", paymentSuccess.getUserId())
+                        .addParameter("employer_id", paymentSuccess.getEmployerId() )
+                        .addParameter("payment_date", paymentSuccess.getPaymentDate())
+                        .addParameter("payment_summ", paymentSuccess.getPaymentSum())
+                        .addParameter("act_id", paymentSuccess.getActId())
+                        .addParameter("candidate", paymentSuccess.getCandidate())
+                        .addParameter("project_id", paymentSuccess.getProjectId())
+                        .addParameter("payment_real_summ", paymentSuccess.getPaymentRealSum())
+                        .addParameter("month_kpi", paymentSuccess.getMonthKPI())
+                        .addParameter("payment_type", paymentSuccess.getType())
+                        .executeUpdate();
+            }
             connection.commit();
 
         }
@@ -96,13 +128,22 @@ public class BonusPaymentSuccessRepositoryImpl implements IBonusPaymentSuccess {
     @Override
     public void deletePayment(int employerId, Double paymentSum, int actId, String candidate, UUID paymentBuhId) {
         try (Connection connection = sql2o.open()) {
-            connection.createQuery(DELETE_BONUS_PAYMENT, false)
-                    .addParameter("user_id", employerId)
-                    .addParameter("payment_summ", paymentSum)
-                    .addParameter("act_id", actId)
-                    .addParameter("candidate", candidate)
-                    .addParameter("payment_buh_id", paymentBuhId)
-                    .executeUpdate();
+            try {
+                connection.createQuery(DELETE_BONUS_PAYMENT, false)
+                        .addParameter("user_id", employerId)
+                        .addParameter("payment_summ", paymentSum)
+                        .addParameter("act_id", actId)
+                        .addParameter("candidate", candidate)
+                        .addParameter("payment_buh_id", paymentBuhId)
+                        .executeUpdate();
+            } catch (Sql2oException e) {
+                connection.createQuery(DELETE_BONUS_PAYMENT_LEGACY, false)
+                        .addParameter("user_id", employerId)
+                        .addParameter("payment_summ", paymentSum)
+                        .addParameter("act_id", actId)
+                        .addParameter("candidate", candidate)
+                        .executeUpdate();
+            }
             connection.commit();
 
         }

--- a/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
@@ -10,7 +10,7 @@ public interface IBonusPaymentSuccess {
     void save(PaymentSuccess paymentSuccess);
     PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ);
     void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate);
-    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate);
+    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate, Integer paymentBuhId);
     void deletePaymentKPI(int employerId, Double paymentSum, String candidate);
     void deletePaymentAll();
 

--- a/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
@@ -10,7 +10,7 @@ public interface IBonusPaymentSuccess {
     void save(PaymentSuccess paymentSuccess);
     PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ);
     void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate);
-    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate, Integer paymentBuhId);
+    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate, String paymentBuhId);
     void deletePaymentKPI(int employerId, Double paymentSum, String candidate);
     void deletePaymentAll();
 

--- a/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/IBonusPaymentSuccess.java
@@ -3,6 +3,7 @@ package ru.alta.thirdproj.repositories;
 import ru.alta.thirdproj.entites.PaymentSuccess;
 
 import java.util.Date;
+import java.util.UUID;
 import java.util.List;
 
 public interface IBonusPaymentSuccess {
@@ -10,7 +11,7 @@ public interface IBonusPaymentSuccess {
     void save(PaymentSuccess paymentSuccess);
     PaymentSuccess findOneByAct(int userId, int actId, String candidate, Double summ);
     void updatePayment(int userId, int employerId, Date paymentDate, Double paymentRealSum, int actId, String candidate);
-    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate, String paymentBuhId);
+    void deletePayment(int employerId, Double paymentRealSum, int actId, String candidate, UUID paymentBuhId);
     void deletePaymentKPI(int employerId, Double paymentSum, String candidate);
     void deletePaymentAll();
 

--- a/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
@@ -24,7 +24,7 @@ public class BonusPaymentSuccessServiceImpl {
 
 
     public boolean addPayment(int userId, int employerId, Double paymentSum, int actId, String candidate,
-                              int projectId, int monthKPI, int type){
+                              int projectId, int monthKPI, int type, Integer paymentBuhId){
 
         PaymentSuccess paymentSuccess = new PaymentSuccess();
 //        if (!findByActId(userId, actId, candidate, paymentSum).isEmpty()) {
@@ -41,6 +41,7 @@ public class BonusPaymentSuccessServiceImpl {
         paymentSuccess.setProjectId(projectId);
         paymentSuccess.setMonthKPI(monthKPI);
         paymentSuccess.setType(type);
+        paymentSuccess.setPaymentBuhId(paymentBuhId);
         bonusPaymentSuccess.save(paymentSuccess);
 
         return true;

--- a/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
@@ -24,7 +24,7 @@ public class BonusPaymentSuccessServiceImpl {
 
 
     public boolean addPayment(int userId, int employerId, Double paymentSum, int actId, String candidate,
-                              int projectId, int monthKPI, int type, String paymentBuhId){
+                              int projectId, int monthKPI, int type, UUID paymentBuhId){
 
         PaymentSuccess paymentSuccess = new PaymentSuccess();
 //        if (!findByActId(userId, actId, candidate, paymentSum).isEmpty()) {
@@ -100,7 +100,7 @@ public class BonusPaymentSuccessServiceImpl {
         }
     }
 
-    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ, String paymentBuhId){
+    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ, UUID paymentBuhId){
 
         if (findByActId(userId, actId, candidate, summ) != null) {
             bonusPaymentSuccess.deletePayment(employerId, paymentRealSum, actId, candidate, paymentBuhId);

--- a/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
@@ -24,7 +24,7 @@ public class BonusPaymentSuccessServiceImpl {
 
 
     public boolean addPayment(int userId, int employerId, Double paymentSum, int actId, String candidate,
-                              int projectId, int monthKPI, int type, Integer paymentBuhId){
+                              int projectId, int monthKPI, int type, String paymentBuhId){
 
         PaymentSuccess paymentSuccess = new PaymentSuccess();
 //        if (!findByActId(userId, actId, candidate, paymentSum).isEmpty()) {
@@ -100,7 +100,7 @@ public class BonusPaymentSuccessServiceImpl {
         }
     }
 
-    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ, Integer paymentBuhId){
+    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ, String paymentBuhId){
 
         if (findByActId(userId, actId, candidate, summ) != null) {
             bonusPaymentSuccess.deletePayment(employerId, paymentRealSum, actId, candidate, paymentBuhId);

--- a/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/BonusPaymentSuccessServiceImpl.java
@@ -100,10 +100,10 @@ public class BonusPaymentSuccessServiceImpl {
         }
     }
 
-    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ){
+    public void deletePayment(int userId, int employerId, LocalDate paymentDate, Double paymentRealSum, int actId, String candidate, Double summ, Integer paymentBuhId){
 
         if (findByActId(userId, actId, candidate, summ) != null) {
-            bonusPaymentSuccess.deletePayment(employerId, paymentRealSum, actId, candidate);
+            bonusPaymentSuccess.deletePayment(employerId, paymentRealSum, actId, candidate, paymentBuhId);
         }
     }
 

--- a/src/main/resources/template/payment.html
+++ b/src/main/resources/template/payment.html
@@ -360,6 +360,7 @@
                                    th:data-bonus="${act.bonus}"
                                    th:data-paid="${act.paid}"
                                    th:data-date-payment="${act.datePayment}"
+                                   th:data-payment-buh-id="${act.paymentBuhId}"
                                    onchange="updatePaymentStatus(this)">
                             <span th:text="${#numbers.formatDecimal(act.bonus, 1, 2, 'COMMA')}"
                                   th:attr="data-value=${act.bonus}"></span>
@@ -445,6 +446,8 @@
         const employerId = parseInt(checkbox.getAttribute('data-employer-id') || 0);
         const candidate = checkbox.getAttribute('data-candidate') || '';
         const datePaymentValue = checkbox.getAttribute('data-date-payment') || '';
+        const paymentBuhIdValue = checkbox.getAttribute('data-payment-buh-id');
+        const paymentBuhId = paymentBuhIdValue ? parseInt(paymentBuhIdValue, 10) : null;
 
         // Валидация данных
         if (!employerId || !candidate || !bonus || bonus <= 0) {
@@ -466,7 +469,8 @@
             bonus: bonus,
             paid: isChecked,
             datePayment: datePaymentValue,
-            paymentRealDate: isChecked ? currentDate : null
+            paymentRealDate: isChecked ? currentDate : null,
+            paymentBuhId: Number.isNaN(paymentBuhId) ? null : paymentBuhId
         };
 
         console.log("Sending payment data:", JSON.stringify(data, null, 2));

--- a/src/main/resources/template/payment.html
+++ b/src/main/resources/template/payment.html
@@ -447,7 +447,7 @@
         const candidate = checkbox.getAttribute('data-candidate') || '';
         const datePaymentValue = checkbox.getAttribute('data-date-payment') || '';
         const paymentBuhIdValue = checkbox.getAttribute('data-payment-buh-id');
-        const paymentBuhId = paymentBuhIdValue ? parseInt(paymentBuhIdValue, 10) : null;
+        const paymentBuhId = paymentBuhIdValue && paymentBuhIdValue !== 'null' ? paymentBuhIdValue : null;
 
         // Валидация данных
         if (!employerId || !candidate || !bonus || bonus <= 0) {
@@ -470,7 +470,7 @@
             paid: isChecked,
             datePayment: datePaymentValue,
             paymentRealDate: isChecked ? currentDate : null,
-            paymentBuhId: Number.isNaN(paymentBuhId) ? null : paymentBuhId
+            paymentBuhId: paymentBuhId
         };
 
         console.log("Sending payment data:", JSON.stringify(data, null, 2));


### PR DESCRIPTION
### Motivation
- Нужно передавать значение `paymentBuhId` из `Act` через UI и контроллер в запись `paymentSuccess` для корректного хранения идентификатора бухгалтера платежа. 
- Необходимо расширить вставку в таблицу `paymentSuccess` и чтение записи, чтобы учитывать колонку `payment_buh_id`.

### Description
- В `PaymentUpdateRequest` добавлено поле `paymentBuhId` и обновлён `toString()` для диагностики входящих запросов. 
- В контроллере `BonusPaymentController` в `POST /amount/updatePaymentStatus` при вызове `paymentSuccessService.addPayment(...)` теперь передаётся `request.getPaymentBuhId()`. 
- В сервисе `BonusPaymentSuccessServiceImpl` расширена сигнатура `addPayment(...)` и значение записывается в `PaymentSuccess` через `setPaymentBuhId(...)`. 
- В сущности `PaymentSuccess` добавлено поле `paymentBuhId` и соответствующая маппинг-строка `COLUMN_MAPPINGS.put("payment_buh_id", "paymentBuhId")`, а в `BonusPaymentSuccessRepositoryImpl` обновлён `INSERT` (`SELECT_BONUS_PAYMENT_QUERY`) с добавлением столбца `payment_buh_id`, добавлен параметр `.addParameter("payment_buh_id", ...)` и `SELECT_ID_BONUS_PAYMENT` теперь выбирает `payment_buh_id`. 
- На фронте в `payment.html` добавлен атрибут `data-payment-buh-id` в checkbox и JS `updatePaymentStatus(...)` теперь включает `paymentBuhId` в JSON тела запроса. 

### Testing
- Попытка сборки через `./mvnw -DskipTests compile` не завершилась из-за сетевой ошибки при загрузке Maven Wrapper дистрибутива (ошибка соединения). 
- Попытка сборки через `mvn -DskipTests compile` не завершилась из-за неразрешимого родительского POM (ошибка 403 при загрузке из внешнего репозитория), поэтому автоматическая компиляция в CI/локально не прошла.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f0ce932548321bdedc64df8634d18)