### PR TITLE
Add personal data statistics page and backend (entity/service/repo/controller)

### DIFF
--- a/src/main/java/ru/alta/thirdproj/controllers/PersonalDataController.java
+++ b/src/main/java/ru/alta/thirdproj/controllers/PersonalDataController.java
@@ -1,0 +1,46 @@
+package ru.alta.thirdproj.controllers;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import ru.alta.thirdproj.entites.PersonalData;
+import ru.alta.thirdproj.services.PersonalDataServiceImpl;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Controller
+@RequestMapping("/personal-data")
+public class PersonalDataController {
+
+    private final PersonalDataServiceImpl personalDataService;
+
+    public PersonalDataController(PersonalDataServiceImpl personalDataService) {
+        this.personalDataService = personalDataService;
+    }
+
+    @GetMapping
+    public String getPersonalDataPage(
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date1,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date2,
+            Model model) {
+
+        if (date1 == null) {
+            date1 = LocalDate.now().withDayOfMonth(1);
+        }
+        if (date2 == null) {
+            date2 = LocalDate.now();
+        }
+
+        List<PersonalData> personalDataList = personalDataService.getPersonalData(date1, date2);
+
+        model.addAttribute("date1", date1);
+        model.addAttribute("date2", date2);
+        model.addAttribute("personalDataList", personalDataList);
+
+        return "personaldate";
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/PersonalData.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PersonalData.java
@@ -16,7 +16,7 @@ public class PersonalData {
     public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
 
     static {
-        COLUMN_MAPPINGS.put("user_name", "userName");
+        COLUMN_MAPPINGS.put("man_fio", "userName");
         COLUMN_MAPPINGS.put("cnt_total", "cntTotal");
         COLUMN_MAPPINGS.put("cnt_confirmed", "cntConfirmed");
         COLUMN_MAPPINGS.put("cnt_not_confirmed", "cntNotConfirmed");

--- a/src/main/java/ru/alta/thirdproj/entites/PersonalData.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PersonalData.java
@@ -1,0 +1,24 @@
+package ru.alta.thirdproj.entites;
+
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class PersonalData {
+
+    private int userId;
+    private int cntTotal;
+    private int cntConfirmed;
+    private int cntNotConfirmed;
+
+    public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
+
+    static {
+        COLUMN_MAPPINGS.put("user_id", "userId");
+        COLUMN_MAPPINGS.put("cnt_total", "cntTotal");
+        COLUMN_MAPPINGS.put("cnt_confirmed", "cntConfirmed");
+        COLUMN_MAPPINGS.put("cnt_not_confirmed", "cntNotConfirmed");
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/entites/PersonalData.java
+++ b/src/main/java/ru/alta/thirdproj/entites/PersonalData.java
@@ -8,7 +8,7 @@ import java.util.Map;
 @Data
 public class PersonalData {
 
-    private int userId;
+    private String userName;
     private int cntTotal;
     private int cntConfirmed;
     private int cntNotConfirmed;
@@ -16,7 +16,7 @@ public class PersonalData {
     public static final Map<String, String> COLUMN_MAPPINGS = new HashMap<>();
 
     static {
-        COLUMN_MAPPINGS.put("user_id", "userId");
+        COLUMN_MAPPINGS.put("user_name", "userName");
         COLUMN_MAPPINGS.put("cnt_total", "cntTotal");
         COLUMN_MAPPINGS.put("cnt_confirmed", "cntConfirmed");
         COLUMN_MAPPINGS.put("cnt_not_confirmed", "cntNotConfirmed");

--- a/src/main/java/ru/alta/thirdproj/repositories/PersonalDataRepository.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/PersonalDataRepository.java
@@ -1,0 +1,32 @@
+package ru.alta.thirdproj.repositories;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.sql2o.Connection;
+import org.sql2o.Sql2o;
+import ru.alta.thirdproj.entites.PersonalData;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class PersonalDataRepository {
+
+    private static final String SELECT_ACT_PAYMENT_QUERY = "select * from fn_personal_data_cnt_by_user(:date1, :date2)";
+
+    private final Sql2o sql2o;
+
+    public PersonalDataRepository(@Autowired Sql2o sql2o) {
+        this.sql2o = sql2o;
+    }
+
+    public List<PersonalData> getPersonalData(LocalDate date1, LocalDate date2) {
+        try (Connection connection = sql2o.open()) {
+            return connection.createQuery(SELECT_ACT_PAYMENT_QUERY, false)
+                    .addParameter("date1", date1)
+                    .addParameter("date2", date2)
+                    .setColumnMappings(PersonalData.COLUMN_MAPPINGS)
+                    .executeAndFetch(PersonalData.class);
+        }
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/repositories/PersonalDataRepository.java
+++ b/src/main/java/ru/alta/thirdproj/repositories/PersonalDataRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Component
 public class PersonalDataRepository {
 
-    private static final String SELECT_ACT_PAYMENT_QUERY = "select * from fn_personal_data_cnt_by_user(:date1, :date2)";
+    private static final String SELECT_PERSONAL_DATA_QUERY = "select * from fn_personal_data_cnt_by_user(:date1, :date2)";
 
     private final Sql2o sql2o;
 
@@ -22,7 +22,7 @@ public class PersonalDataRepository {
 
     public List<PersonalData> getPersonalData(LocalDate date1, LocalDate date2) {
         try (Connection connection = sql2o.open()) {
-            return connection.createQuery(SELECT_ACT_PAYMENT_QUERY, false)
+            return connection.createQuery(SELECT_PERSONAL_DATA_QUERY, false)
                     .addParameter("date1", date1)
                     .addParameter("date2", date2)
                     .setColumnMappings(PersonalData.COLUMN_MAPPINGS)

--- a/src/main/java/ru/alta/thirdproj/services/PersonalDataServiceImpl.java
+++ b/src/main/java/ru/alta/thirdproj/services/PersonalDataServiceImpl.java
@@ -1,0 +1,25 @@
+package ru.alta.thirdproj.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.alta.thirdproj.entites.PersonalData;
+import ru.alta.thirdproj.repositories.PersonalDataRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class PersonalDataServiceImpl implements iPersonalData {
+
+    private PersonalDataRepository personalDataRepository;
+
+    @Autowired
+    public void setPersonalDataRepository(PersonalDataRepository personalDataRepository) {
+        this.personalDataRepository = personalDataRepository;
+    }
+
+    @Override
+    public List<PersonalData> getPersonalData(LocalDate date1, LocalDate date2) {
+        return personalDataRepository.getPersonalData(date1, date2);
+    }
+}

--- a/src/main/java/ru/alta/thirdproj/services/iPersonalData.java
+++ b/src/main/java/ru/alta/thirdproj/services/iPersonalData.java
@@ -1,0 +1,10 @@
+package ru.alta.thirdproj.services;
+
+import ru.alta.thirdproj.entites.PersonalData;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface iPersonalData {
+    List<PersonalData> getPersonalData(LocalDate date1, LocalDate date2);
+}

--- a/src/main/resources/template/navigation.html
+++ b/src/main/resources/template/navigation.html
@@ -105,6 +105,9 @@
                 <li class="nav-item" th:classappend="${activeTab} == 'BonusSchemes' ? 'active'">
                     <a class="nav-link" th:href="@{/bonus-schemes}">Бонусные схемы</a>
                 </li>
+                <li class="nav-item" th:classappend="${activeTab} == 'PersonalData' ? 'active'">
+                    <a class="nav-link" th:href="@{/personal-data}">Согласия ПД</a>
+                </li>
             </ul>
         </div>
     </nav>

--- a/src/main/resources/template/personaldate.html
+++ b/src/main/resources/template/personaldate.html
@@ -19,11 +19,15 @@
             overflow-x: auto;
         }
 
-        .fixed-header thead th {
+        .fixed-header thead {
             position: sticky;
             top: 56px;
-            background: white;
             z-index: 1020;
+        }
+
+        .fixed-header thead th {
+            background-color: #f8f9fa;
+            border-bottom: 2px solid #dee2e6;
             box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
         }
 
@@ -102,12 +106,12 @@
 
                 <div class="table-container">
                     <table class="table table-bordered table-hover fixed-header">
-                        <thead>
+                        <thead class="table-light">
                         <tr>
-                            <th>Пользователь</th>
-                            <th>Всего согласий</th>
-                            <th>Подтверждено</th>
-                            <th>Не подтверждено</th>
+                            <th scope="col">Пользователь</th>
+                            <th scope="col">Всего согласий</th>
+                            <th scope="col">Подтверждено</th>
+                            <th scope="col">Не подтверждено</th>
                         </tr>
                         </thead>
                         <tbody>

--- a/src/main/resources/template/personaldate.html
+++ b/src/main/resources/template/personaldate.html
@@ -104,7 +104,7 @@
                     <table class="table table-bordered table-hover fixed-header">
                         <thead>
                         <tr>
-                            <th>ID пользователя</th>
+                            <th>Пользователь</th>
                             <th>Всего согласий</th>
                             <th>Подтверждено</th>
                             <th>Не подтверждено</th>
@@ -115,7 +115,7 @@
                             <td colspan="4" class="text-center text-muted">Нет данных за выбранный период</td>
                         </tr>
                         <tr th:each="item : ${personalDataList}">
-                            <td th:text="${item.userId}"></td>
+                            <td th:text="${item.userName}"></td>
                             <td th:text="${item.cntTotal}"></td>
                             <td th:text="${item.cntConfirmed}"></td>
                             <td th:text="${item.cntNotConfirmed}"></td>

--- a/src/main/resources/template/personaldate.html
+++ b/src/main/resources/template/personaldate.html
@@ -20,12 +20,9 @@
         }
 
         .fixed-header thead th {
-            position: sticky;
-            top: 56px;
-            z-index: 1020;
             background-color: #f8f9fa !important;
             border-bottom: 2px solid #dee2e6;
-            box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
+            box-shadow: none;
         }
 
         td {

--- a/src/main/resources/template/personaldate.html
+++ b/src/main/resources/template/personaldate.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Согласия на обработку персональных данных</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .navbar {
+            z-index: 1030;
+        }
+
+        .main-content {
+            position: relative;
+            padding-top: 56px;
+        }
+
+        .table-container {
+            position: relative;
+            overflow-x: auto;
+        }
+
+        .fixed-header thead th {
+            position: sticky;
+            top: 56px;
+            background: white;
+            z-index: 1020;
+            box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        td {
+            vertical-align: middle;
+            padding: 0.5rem !important;
+        }
+
+        tr:hover td {
+            background-color: #f8f9fa !important;
+        }
+
+        .table-width-limiter {
+            max-width: 100%;
+            padding-left: 15px;
+            padding-right: 15px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .stats-block {
+            background-color: transparent;
+            padding: 0;
+            margin-bottom: 20px;
+            border-radius: 0;
+            border: none;
+        }
+
+        .stats-block .bg-light {
+            background-color: #f8f9fa !important;
+            padding: 15px;
+            border-radius: 5px;
+            border: 1px solid #dee2e6;
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+<div th:replace="~{navigation :: navi('PersonalData')}"></div>
+
+<div class="main-content">
+    <div class="container-fluid mt-4 px-3">
+        <div class="row justify-content-center">
+            <div class="col-12 table-width-limiter">
+                <h2>Статистика отправки согласий на обработку персональных данных</h2>
+
+                <form method="get" th:action="@{/personal-data}" class="mb-4">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label for="date1" class="form-label">От:</label>
+                            <input type="date" class="form-control" id="date1" name="date1"
+                                   th:value="${date1 != null ? #temporals.format(date1, 'yyyy-MM-dd') : ''}">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="date2" class="form-label">До:</label>
+                            <input type="date" class="form-control" id="date2" name="date2"
+                                   th:value="${date2 != null ? #temporals.format(date2, 'yyyy-MM-dd') : ''}">
+                        </div>
+                        <div class="col-md-2 align-self-end">
+                            <button type="submit" class="btn btn-primary">Применить</button>
+                        </div>
+                    </div>
+                </form>
+
+                <div class="stats-block row mx-0 mb-3" th:if="${personalDataList != null}">
+                    <div class="col-md-4 px-2">
+                        <div class="bg-light">
+                            <p class="mb-0">
+                                Период: <span th:text="${#temporals.format(date1, 'dd.MM.yyyy')}"></span>
+                                -
+                                <span th:text="${#temporals.format(date2, 'dd.MM.yyyy')}"></span>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="table-container">
+                    <table class="table table-bordered table-hover fixed-header">
+                        <thead>
+                        <tr>
+                            <th>ID пользователя</th>
+                            <th>Всего согласий</th>
+                            <th>Подтверждено</th>
+                            <th>Не подтверждено</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:if="${personalDataList == null || personalDataList.isEmpty()}">
+                            <td colspan="4" class="text-center text-muted">Нет данных за выбранный период</td>
+                        </tr>
+                        <tr th:each="item : ${personalDataList}">
+                            <td th:text="${item.userId}"></td>
+                            <td th:text="${item.cntTotal}"></td>
+                            <td th:text="${item.cntConfirmed}"></td>
+                            <td th:text="${item.cntNotConfirmed}"></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/template/personaldate.html
+++ b/src/main/resources/template/personaldate.html
@@ -19,14 +19,11 @@
             overflow-x: auto;
         }
 
-        .fixed-header thead {
+        .fixed-header thead th {
             position: sticky;
             top: 56px;
             z-index: 1020;
-        }
-
-        .fixed-header thead th {
-            background-color: #f8f9fa;
+            background-color: #f8f9fa !important;
             border-bottom: 2px solid #dee2e6;
             box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1);
         }


### PR DESCRIPTION
### Motivation
- Добавить страницу статистики отправки согласий на обработку персональных данных и связать её с backend в том же стиле, что и существующие страницы (энтити → репозиторий → сервис → контроллер → шаблон). 
- Обеспечить получение данных по периоду через SQL-функцию `fn_personal_data_cnt_by_user(:date1, :date2)` и отобразить их в табличном виде с двумя датами-фильтрами.

### Description
- Добавлена сущность `PersonalData` с полями `userId`, `cntTotal`, `cntConfirmed`, `cntNotConfirmed` и `COLUMN_MAPPINGS` для `Sql2o` (файл `src/main/java/ru/alta/thirdproj/entites/PersonalData.java`).
- Добавлен репозиторий `PersonalDataRepository` с запросом `select * from fn_personal_data_cnt_by_user(:date1, :date2)` и методом `getPersonalData(LocalDate date1, LocalDate date2)` (файл `src/main/java/ru/alta/thirdproj/repositories/PersonalDataRepository.java`).
- Добавлен публичный интерфейс `iPersonalData` и реализация `PersonalDataServiceImpl`, которые возвращают список `PersonalData` по датам (файлы `src/main/java/ru/alta/thirdproj/services/iPersonalData.java` и `src/main/java/ru/alta/thirdproj/services/PersonalDataServiceImpl.java`).
- Создан контроллер `PersonalDataController` с `@RequestMapping("/personal-data")`, принимающий два параметра-даты и рендерящий `personaldate.html` (файл `src/main/java/ru/alta/thirdproj/controllers/PersonalDataController.java`).
- Добавлен Thymeleaf-шаблон `personaldate.html` с двумя `input type="date"`, кнопкой применения и таблицей для отображения статистики (файл `src/main/resources/template/personaldate.html`).
- В навигацию (`navigation.html`) добавлена ссылка с активным табом `PersonalData` (`Согласия ПД`) для доступа к странице (файл `src/main/resources/template/navigation.html`).

### Testing
- Выполнен автоматический синтаксический/статический чек изменений через `git diff --check` на изменённых файлах, проверка прошла успешно. 
- Попытка собрать проект `mvn -q -DskipTests compile` была выполнена и завершилась с ошибкой в этом окружении из-за невозможности разрешить родительский POM `org.springframework.boot:spring-boot-starter-parent:2.6.6` через настроенный репозиторий (HTTP 403), поэтому полная сборка/compile не прошла в CI-окружении здесь.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baaeb0c85c8321ad6730c2918e5633)