### PR TITLE
Add client-side Excel export to personaldata page

### DIFF
--- a/src/main/resources/template/personaldate.html
+++ b/src/main/resources/template/personaldate.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Согласия на обработку персональных данных</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <style>
         .navbar {
             z-index: 1030;
@@ -83,6 +84,11 @@
                         <div class="col-md-2 align-self-end">
                             <button type="submit" class="btn btn-primary">Применить</button>
                         </div>
+                        <div class="col-md-3 align-self-end">
+                            <button type="button" class="btn btn-success" onclick="exportPersonalDataToExcel()">
+                                Выгрузить в Excel
+                            </button>
+                        </div>
                     </div>
                 </form>
 
@@ -125,5 +131,42 @@
         </div>
     </div>
 </div>
+<script>
+    function exportPersonalDataToExcel() {
+        const tableRows = document.querySelectorAll('.table-container table tbody tr');
+        const data = [];
+
+        tableRows.forEach(row => {
+            const cells = row.querySelectorAll('td');
+            if (cells.length !== 4) {
+                return;
+            }
+
+            if (cells[0].classList.contains('text-muted')) {
+                return;
+            }
+
+            data.push({
+                'Пользователь': cells[0].innerText.trim(),
+                'Всего согласий': cells[1].innerText.trim(),
+                'Подтверждено': cells[2].innerText.trim(),
+                'Не подтверждено': cells[3].innerText.trim()
+            });
+        });
+
+        if (!data.length) {
+            alert('Нет данных для выгрузки.');
+            return;
+        }
+
+        const worksheet = XLSX.utils.json_to_sheet(data);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, 'Согласия ПД');
+
+        const dateFrom = document.getElementById('date1')?.value || 'from';
+        const dateTo = document.getElementById('date2')?.value || 'to';
+        XLSX.writeFile(workbook, `personal_data_${dateFrom}_${dateTo}.xlsx`);
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to download the displayed personal data consent statistics as an Excel file from the `personaldate` page.

### Description
- Added SheetJS by including `<script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>` in `personaldate.html`.
- Added a `Выгрузить в Excel` button next to the date filters that calls `exportPersonalDataToExcel()`.
- Implemented `exportPersonalDataToExcel()` JavaScript that reads the table body rows, skips the "Нет данных" placeholder, builds a workbook via `XLSX.utils.json_to_sheet`, and writes a file named with the selected `date1`/`date2` range.

### Testing
- No automated tests were run for this change because it is a client-side template-only addition; changes were committed and a diff/stat check was performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64e445ca88321b411fa12f1486319)